### PR TITLE
修复端口设置为0，本地监听时候，订阅端口不切成0的bug

### DIFF
--- a/app/Utils/Tools.php
+++ b/app/Utils/Tools.php
@@ -447,7 +447,7 @@ class Tools
             'tls' => ''
         ];
         $item['add'] = $server[0];
-        if ($server[1] == '0' && $server[1] == '') {
+        if ($server[1] == '0' || $server[1] == '') {
             $item['port'] = 443;
         } else {
             $item['port'] = (int)$server[1];
@@ -500,7 +500,7 @@ class Tools
             'tls' => ''
         ];
         $item['add'] = $server[0];
-        if ($server[1] == '0' && $server[1] == '') {
+        if ($server[1] == '0' || $server[1] == '') {
             $item['port'] = 443;
         } else {
             $item['port'] = (int)$server[1];


### PR DESCRIPTION
紧急修复了原先的二逼bug，

1. 修复端口设置为0或者为空的时候不按照之前规则，自动切换成443的订阅的bug