### PR TITLE
修复Clash完整订阅中Auto覆盖第一个代理的bug

### DIFF
--- a/app/Utils/Tools.php
+++ b/app/Utils/Tools.php
@@ -447,7 +447,7 @@ class Tools
             'tls' => ''
         ];
         $item['add'] = $server[0];
-        if ($server[1] == '0' && $server[1] == '') {
+        if ($server[1] == '0' || $server[1] == '') {
             $item['port'] = 443;
         } else {
             $item['port'] = (int)$server[1];
@@ -500,7 +500,7 @@ class Tools
             'tls' => ''
         ];
         $item['add'] = $server[0];
-        if ($server[1] == '0' && $server[1] == '') {
+        if ($server[1] == '0' || $server[1] == '') {
             $item['port'] = 443;
         } else {
             $item['port'] = (int)$server[1];

--- a/resources/conf/clash.tpl
+++ b/resources/conf/clash.tpl
@@ -38,7 +38,8 @@ Proxy:
 
 Proxy Group:
   - { name: "Auto", type: fallback, proxies: {json_encode($proxies,320)}, url: "http://www.gstatic.com/generate_204", interval: 300 }
-{append var='proxies' value='Auto' index=0}
+{$tmp[] = "Auto"}
+{assign 'proxies' $tmp|array_merge:$proxies}
   - { name: "Proxy", type: select, proxies: {json_encode($proxies,320)} }
   - { name: "Domestic", type: select, proxies: ["DIRECT","Proxy"] }
 {$China_media=["Domestic","Proxy"]}


### PR DESCRIPTION
1. 修复了在smarty template中使用append时候，因为规定了index =0，造成第一个代理被替换的bug