### PR TITLE
feat/ci: add smarty lint & npm audit to ci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ storage/*.*
 public/.user.ini
 
 resources/views/material/analytics.tpl
+
+test/tpl_files.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ install:
   - npm i
   - cd ..
   - if [[ ! -n "$(git log -1 --pretty=%B | grep 'skip lint')" ]]; then
-      cd test && git vlonr https://github.com/erunion/smarty-lint && cd .. ;
+      cd test && git clone https://github.com/erunion/smarty-lint && cd .. ;
     fi
 before_script:
   - cd uim-index-dev
@@ -66,7 +66,7 @@ before_script:
     fi
   - chmod +x ./test/listTpl.sh
   - if [[ ! -n "$(git log -1 --pretty=%B | grep 'skip lint')" ]]; then
-      ./test/listTpl.sh
+      ./test/listTpl.sh;
     fi
 script:
   - cp config/.config.example.php config/.config.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,7 @@ before_script:
   - if [[ ! -n "$(git log -1 --pretty=%B | grep 'skip lint')" ]]; then
       npm run lint;
     fi
+  - npm audit
   - npm run build
   - cd ..
   - if [[ ! -n "$(git log -1 --pretty=%B | grep 'skip lint')" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ before_script:
   - if [[ ! -n "$(git log -1 --pretty=%B | grep 'skip lint')" ]]; then
       npm run lint;
     fi
-  - npm audit
+  - npm audit || true
   - npm run build
   - cd ..
   - if [[ ! -n "$(git log -1 --pretty=%B | grep 'skip lint')" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,9 @@ install:
   - cd uim-index-dev
   - npm i
   - cd ..
+  - if [[ ! -n "$(git log -1 --pretty=%B | grep 'skip lint')" ]]; then
+      cd test && git vlonr https://github.com/erunion/smarty-lint && cd .. ;
+    fi
 before_script:
   - cd uim-index-dev
   - if [[ ! -n "$(git log -1 --pretty=%B | grep 'skip lint')" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,10 @@ before_script:
   - if [[ ! -n "$(git log -1 --pretty=%B | grep 'skip lint')" ]]; then
       phplint '**/*.php' '!vendor/**';
     fi
+  - chmod +x ./test/listTpl.sh
+  - if [[ ! -n "$(git log -1 --pretty=%B | grep 'skip lint')" ]]; then
+      ./test/listTpl.sh
+    fi
 script:
   - cp config/.config.example.php config/.config.php
   - php xcat createAdmin test@example.com test

--- a/test/listTpl.sh
+++ b/test/listTpl.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+find ./ -name "*.tpl" > ./test/tpl_files.txt
+
+while read LINE
+do
+    echo '--------------------------------------------------'
+    echo $LINE
+    echo '--------------------------------------------------'
+    ./test/smart-lint/smart-lint "$LINE" y
+done < ./test/tpl_files.txt

--- a/test/listTpl.sh
+++ b/test/listTpl.sh
@@ -6,5 +6,5 @@ do
     echo '--------------------------------------------------'
     echo $LINE
     echo '--------------------------------------------------'
-    ./test/smart-lint/smart-lint "$LINE" y
+    ./test/smarty-lint/smarty-lint "$LINE" y
 done < ./test/tpl_files.txt


### PR DESCRIPTION
Although th [smarty-lint](https://github.com/erunion/smarty-lint) added in this PR is such an antique, it is still usable at this moment.

If someone want to rewrite the `smarty-lint`, just fork the origin `smarty-lint` repo.