### PR TITLE
排除已经中止的套餐

### DIFF
--- a/app/Command/Job.php
+++ b/app/Command/Job.php
@@ -153,7 +153,7 @@ class Job
         Telegram::Send('姐姐姐姐，数据库被清理了，感觉身体被掏空了呢~');
 
         //auto reset
-        $boughts = Bought::all();
+        $boughts = Bought::where('renew', '<>', 0)->get();
         $boughted_users = array();
         foreach ($boughts as $bought) {
             $user = User::where('id', $bought->userid)->first();


### PR DESCRIPTION
1. 在DailyJob中，排除renew==0的购买过的套餐，防止重复更新用户流量。