### PR TITLE
fix: codepay error, it uses new api LINK, see more at: https://codepa…

### DIFF
--- a/app/Services/Gateway/Codepay.php
+++ b/app/Services/Gateway/Codepay.php
@@ -87,7 +87,7 @@ class Codepay extends AbstractPayment
             $urls .= "$key=" . urlencode($val); //拼接为url参数形式并URL编码参数值
         }
         $query = $urls . '&sign=' . md5($sign . $codepay_key); //创建订单所需的参数
-        $url = 'https://codepay.fateqq.com:51888/creat_order/?' . $query; //支付页面
+        $url = 'https://codepay.fateqq.com/creat_order/?' . $query; //支付页面
 
 
         header('Location:' . $url);


### PR DESCRIPTION
fix: codepay error, it uses new api LINK, see more at: https://codepay.fateqq.com/apiword/r1YwqrOte.html

it caused most telecom users to be unable to take the payment net-work line since 2019.07.26 10:00