### PR TITLE
fix: 修复不能识别$debug字段, 本地开发环境无法进入index的bug

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -36,7 +36,7 @@ $container['notAllowedHandler'] = static function ($c) {
     };
 };
 
-if ($debug == false) {
+if (DEBUG == false) {
     $container['errorHandler'] = static function ($c) {
         return static function ($request, $response, $exception) use ($c) {
             return $response->withAddedHeader('Location', '/500');


### PR DESCRIPTION
闲了想写个功能，结果发现本地运行php7.2 or 7.3 均无法进入index，第一时间往回切commit，本地部署发现没有问题
第二时间定位bug发现字段$debug不认，对比发现改成全局DEBUG字段这里少改了一行？
不知道大佬是怎么本地调试开发的，我是phpstorm2019.2.1的build-in web + php7.3，本地报错
config文件里
`$System_Config['debug'] =  false;								//正式环境请确保为 false`
不管是false和true都没用
恕我表达能力欠佳，还是贴个图好了
 - 发现bug时
![image](https://user-images.githubusercontent.com/42567368/64675451-ccab9500-d4a5-11e9-909f-f18bb97e11fb.png)
![image](https://user-images.githubusercontent.com/42567368/64675459-d208df80-d4a5-11e9-9684-7a884d0b890f.png)
 - 修改字段后
![image](https://user-images.githubusercontent.com/42567368/64675505-ebaa2700-d4a5-11e9-9da0-293b749848d7.png)
![image](https://user-images.githubusercontent.com/42567368/64675536-fb297000-d4a5-11e9-820b-c5e0a051f448.png)


