### PR TITLE
fix smtp: 修正发信名显示

### DIFF
--- a/app/Services/Mail/Smtp.php
+++ b/app/Services/Mail/Smtp.php
@@ -19,6 +19,7 @@ class Smtp extends Base
         $mail->isSMTP();                                      // Set mailer to use SMTP
         $mail->Host = $this->config['host'];  // Specify main and backup SMTP servers
         $mail->SMTPAuth = true;                               // Enable SMTP authentication
+        $mail->FromName = $this->config['sender'];                   // SMTP Sender Name
         $mail->Username = $this->config['username'];                 // SMTP username
         $mail->Password = $this->config['passsword'];                    // SMTP password
         if ($_ENV['smtp_ssl'] == true) {


### PR DESCRIPTION
部分邮局使用`FromName` 作为发件名，此值留空时默认使用 `Root User` 100% 进垃圾信箱