### PR TITLE
Fix bug: calIncome function error

### DIFF
--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -393,10 +393,15 @@ class User extends Model
     			$number = Code::whereDate('usedatetime', '=', date('Y-m-d'))->sum('number');
     			break;
     		case "this month":
-    			$number = Code::whereMonth('usedatetime', '=', date('m'))->sum('number');
+    			$number = Code::whereYear('usedatetime', '=', date('Y'))->whereMonth('usedatetime', '=', date('m'))->sum('number');
     			break;
     		case "last month":
-    			$number = Code::whereMonth('usedatetime', '=', date('m',strtotime('first day of last month')))->sum('number');
+    			if (date('m') == '1'){
+    				$number = Code::whereYear('usedatetime', '=', date('Y',strtotime('-1 year')))->whereMonth('usedatetime', '=', '12')->sum('number');
+    			}
+    			else{
+    				$number = Code::whereYear('usedatetime', '=', date('Y'))->whereMonth('usedatetime', '=', date('m',strtotime('first day of last month')))->sum('number');
+    			}
     			break;
     		default:
     			$number = Code::sum('number');

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -396,7 +396,7 @@ class User extends Model
     			$number = Code::whereMonth('usedatetime', '=', date('m'))->sum('number');
     			break;
     		case "last month":
-    			$number = Code::whereMonth('usedatetime', '=', date('m',strtotime('last month')))->sum('number');
+    			$number = Code::whereMonth('usedatetime', '=', date('m',strtotime('first day of last month')))->sum('number');
     			break;
     		default:
     			$number = Code::sum('number');


### PR DESCRIPTION
Fixed retrieval of last month income error at strtotime('last month')
Bug happens on 31st as there is no 31st on last month.