### PR TITLE
Add node_connector for users api

### DIFF
--- a/src/Controllers/Mod_Mu/UserController.php
+++ b/src/Controllers/Mod_Mu/UserController.php
@@ -72,7 +72,7 @@ class UserController extends BaseController
 
         $key_list = array('email', 'method', 'obfs', 'obfs_param', 'protocol', 'protocol_param',
             'forbidden_ip', 'forbidden_port', 'node_speedlimit', 'disconnect_ip',
-            'is_multi_user', 'id', 'port', 'passwd', 'u', 'd');
+            'is_multi_user', 'id', 'port', 'passwd', 'u', 'd', 'node_connector');
 
         foreach ($users_raw as $user_raw) {
             if ($user_raw->transfer_enable > $user_raw->u + $user_raw->d) {


### PR DESCRIPTION
Hi there~

I've implemented an v2ray-server, [v2ray-poseidon](https://github.com/ColetteContreras/v2ray-poseidon/wiki/00-%E5%85%AC%E5%91%8A%E5%92%8C%E6%9B%B4%E6%96%B0%E6%97%A5%E5%BF%97#v120), which can limit users simultaneous online IP count accurately. ONLY one way to get the amount is by API

Thanks~