### PR TITLE
feat(login): better 2fa solution

### DIFF
--- a/resources/views/material/auth/login.tpl
+++ b/resources/views/material/auth/login.tpl
@@ -31,7 +31,7 @@
                 <div class="auth-row">
                     <div class="form-group-label auth-row row-login">
                         <label class="floating-label" for="code">两步验证码（未设置请忽略）</label>
-                        <input class="form-control maxwidth-auth" id="code" type="text" name="Code">
+                        <input class="form-control maxwidth-auth" id="code" type="number" name="Code" inputmode="numeric" autocomplete="one-time-code">
                     </div>
                 </div>
 


### PR DESCRIPTION
- Use inputmode="numeric" for better iOS experience
- Use autocomplete="one-time-code" for Safari/Chrome support