### PR TITLE
修复新bot的管理员权限bug

### DIFF
--- a/src/Utils/Telegram/Commands/SetuserCommand.php
+++ b/src/Utils/Telegram/Commands/SetuserCommand.php
@@ -68,8 +68,8 @@ class SetuserCommand extends Command
                         'chatid'      => $ChatID,
                         'messageid'   => $response->getMessageId(),
                     ]);
-                    return;
                 }
+                return;
             }
         }
 


### PR DESCRIPTION
1. 修复任意人员都可以admin修改的问题
2. 提醒，如果需要非管理员回复，请配置$_ENV['enable_not_admin_reply'] = true && $_ENV['not_admin_reply_msg']="xxxxx"
3. 升级过程中 config.example.php 和 appprofile.example.php 记得抄一下 感恩
#980 