### PR TITLE
feat(docs): 优化本地文档

### DIFF
--- a/config/.config.example.php
+++ b/config/.config.example.php
@@ -361,7 +361,13 @@ $_ENV['use_this_doc']         = false;	    //使用此文档
 $_ENV['enable_documents']     = false;	    //是否允许未登陆用户查看文档中心
 $_ENV['documents_name']       = $_ENV['appName'] . ' 文档中心';	    //文档中心名称
 $_ENV['remote_documents']     = true;	    //是否从远程加载文档中心，否的话请执行 php xcat initdocuments
-$_ENV['documents_source']     = 'https://raw.githubusercontent.com/GeekQu/PANEL_DOC/master/SSPanel';	    //远程文档加载地址
+/**
+ * 文档地址示例
+ * 本地文档同步: https://github.com/GeekQuerxy/PANEL_DOC.git
+ * 远程在线文档: https://raw.githubusercontent.com/GeekQu/PANEL_DOC/master/SSPanel
+ */
+$_ENV['documents_source']     = 'https://raw.githubusercontent.com/GeekQu/PANEL_DOC/master/SSPanel';
+$_ENV['docs_branche'] = 'origin/master'; // 如果是本地文档，指定远程分支可在 crontab 添加定时同步
 
 #后台商品列表 销量统计
 $_ENV['sales_period']         = 30;             //统计指定周期内的销量，值为【expire/任意大于0的整数】

--- a/src/Command/Tool.php
+++ b/src/Command/Tool.php
@@ -72,7 +72,8 @@ class Tool extends Command
      */
     public function initdocuments()
     {
-        system('git clone https://github.com/GeekQuerxy/PANEL_DOC.git ' . BASE_PATH . "/public/docs/", $ret);
+        $docs_path = BASE_PATH . '/public/docs/';
+        system('(ls ' . $docs_path . ' || git clone ' . $_ENV['documents_source'] . ' ' . $docs_path . ') && (cd ' . $docs_path . ' && git fetch --all && git reset --hard ' . $_ENV['docs_branche'] . ')', $ret);
         echo $ret;
     }
 


### PR DESCRIPTION
网络环境不稳定的客户会打不开 `raw.githubusercontent.com` ，本地的文档不会自动更新，就咕咕了个这么玩意儿，机场主可以通过添加 `crontab` 并修改文档地址为自己 Frok 的 GitHub 地址来达到自动同步。
```bash 
*/20 * * * * php /www/wwwroot/store/xcat initdocuments > /dev/null
```