### PR TITLE
Add DNS field to Clash configuration

### DIFF
--- a/config/appprofile.example.php
+++ b/config/appprofile.example.php
@@ -251,6 +251,28 @@ $_ENV['Clash_Profiles'] = [
             'external-controller' => '0.0.0.0:9090',
             'secret'              => ''
         ],
+        'DNS' => [
+            'enable'              => true,
+            'ipv6'                => false,
+            'listen'              => '0.0.0.0:53',
+            'enhanced-mode'       => 'fake-ip',
+            'fake-ip-range'       => '198.18.0.1/16',
+            'enable'              => true,
+            'nameserver'=>[
+                '114.114.114.114',
+                'tcp://1.1.1.1'
+            ],
+            'fallback'=>[
+                'tls://dns.rubyfish.cn:853',
+                'https://1.1.1.1/dns-query'
+            ],
+            'fallback-filter'=>[
+                'geoip'=> true,
+                'ipcidr'=>[
+                    '240.0.0.0/4'
+                ]
+            ]
+        ],
         'Proxy' => [],
         'ProxyGroup' => [
             [

--- a/config/appprofile.example.php
+++ b/config/appprofile.example.php
@@ -263,7 +263,7 @@ $_ENV['Clash_Profiles'] = [
                 'tcp://1.1.1.1'
             ],
             'fallback'=>[
-                'tls://dns.rubyfish.cn:853',
+                'tls://223.5.5.5:853',
                 'https://1.1.1.1/dns-query'
             ],
             'fallback-filter'=>[

--- a/config/appprofile.example.php
+++ b/config/appprofile.example.php
@@ -260,11 +260,11 @@ $_ENV['Clash_Profiles'] = [
             'enable'              => true,
             'nameserver'=>[
                 '114.114.114.114',
-                'tcp://1.1.1.1'
+                'tcp://223.5.5.5'
             ],
             'fallback'=>[
                 'tls://223.5.5.5:853',
-                'https://1.1.1.1/dns-query'
+                'https://223.5.5.5/dns-query'
             ],
             'fallback-filter'=>[
                 'geoip'=> true,

--- a/src/Controllers/ConfController.php
+++ b/src/Controllers/ConfController.php
@@ -327,6 +327,7 @@ class ConfController extends BaseController
         }
 
         $tmp = $Configs['General'];
+        $tmp['dns'] = $Configs['DNS'];
         $tmp['proxies'] = $Proxys;
         if (isset($Configs['Proxy Group'])) {
             $Configs['ProxyGroup'] = $Configs['Proxy Group'];


### PR DESCRIPTION
解决QUIC模式下，因DNS解析问题导致的ERR_QUIC_PROTOCOL_ERROR问题，解决方案是向配置文件中添加dns配置区块，指定DNS服务器。

遇到的实际问题：在最新版的 Clash for Android 上访问 www.google.com 报错 `ERR_QUIC_PROTOCOL_ERROR`，但是却能正常访问 www.google.com.hk、www.youtube.com 等网站，相关报告见这个issue：https://github.com/Kr328/ClashForAndroid/issues/624