### PR TITLE
Update Job.php

### DIFF
--- a/src/Command/Job.php
+++ b/src/Command/Job.php
@@ -558,11 +558,12 @@ class Job extends Command
                         $under_limit = true;
                         $unit_text = '%';
                     }
-                } elseif ($_ENV['notify_limit_mode'] == 'mb' &&
-                    Tools::flowToMB($user_traffic_left) < $_ENV['notify_limit_value']
-                ) {
-                    $under_limit = true;
-                    $unit_text = 'MB';
+                    elseif ($_ENV['notify_limit_mode'] == 'mb' &&
+                        Tools::flowToMB($user_traffic_left) < $_ENV['notify_limit_value']
+                    ) {
+                        $under_limit = true;
+                        $unit_text = 'MB';
+                    }
                 }
 
                 if ($under_limit == true && $user->traffic_notified == false) {


### PR DESCRIPTION
解决余量不足检测设置成 mb 时, $user->transfer_enable != 0 && $user->class !=0 的用户无法收到通知邮件问题