### PR TITLE
统一声明页面语言标签

### DIFF
--- a/resources/views/material/404.tpl
+++ b/resources/views/material/404.tpl
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<html>
+<html lang="zh-cn">
 <head>
     <title>页面无法找到哦 - {$config['appName']} </title>
     <meta name="keywords" content=""/>

--- a/resources/views/material/405.tpl
+++ b/resources/views/material/405.tpl
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<html>
+<html lang="zh-cn">
 <head>
     <title>您的访问方式不正确 - {$config['appName']} </title>
     <meta name="keywords" content=""/>

--- a/resources/views/material/500.tpl
+++ b/resources/views/material/500.tpl
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<html>
+<html lang="zh-cn">
 <head>
     <title>该网页无法正常运作 - {$config['appName']}</title>
     <meta name="keywords" content=""/>

--- a/resources/views/material/doc/index.tpl
+++ b/resources/views/material/doc/index.tpl
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="zh-cn">
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
   <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/resources/views/material/indexold.tpl
+++ b/resources/views/material/indexold.tpl
@@ -4,7 +4,7 @@
     html5up.net | @ajlkn
     Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
 -->
-<html>
+<html lang="zh-cn">
 <head>
     <meta charset="utf-8"/>
     <title>{$config['appName']}</title>

--- a/resources/views/material/staff.tpl
+++ b/resources/views/material/staff.tpl
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html>
+<html lang="zh-cn">
 
 <head>
     <title>{$config['appName']}</title>

--- a/resources/views/material/telegram_error.tpl
+++ b/resources/views/material/telegram_error.tpl
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<html>
+<html lang="zh-cn">
 <head>
     <title>产生了一个错误 - {$config['appName']} </title>
     <meta name="keywords" content=""/>

--- a/resources/views/material/telegram_success.tpl
+++ b/resources/views/material/telegram_success.tpl
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<html>
+<html lang="zh-cn">
 <head>
     <title>正在跳转用户中心 - {$config['appName']} </title>
     <meta name="keywords" content=""/>

--- a/resources/views/material/tos.tpl
+++ b/resources/views/material/tos.tpl
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<html>
+<html lang="zh-cn">
 <head>
     <title>{$config['appName']}</title>
     <meta name="keywords" content="{$config['appName']}"/>


### PR DESCRIPTION
部分页面已有声明页面语言，但大部分没有
此次 PR 的目的皆在为默认 material 主题统一增加页面语言声明，以解决在非中文浏览器环境下浏览部分未声明语言的页面，默认调用非中文字体的情况，影响阅读