### PR TITLE
修复查询多个购买记录重置流量的bug

### DIFF
--- a/src/Command/Job.php
+++ b/src/Command/Job.php
@@ -134,7 +134,7 @@ class Job extends Command
         }
 
         //auto reset
-        $boughts = Bought::all();
+        $boughts = Bought::whereIn('id', Bought::groupBy(userid)->where('renew','=','1')->max('id'));
         $bought_users = array();
         foreach ($boughts as $bought) {
             $user = User::where('id', $bought->userid)->first();


### PR DESCRIPTION
仅提取最新的可重置购买记录做重置匹配，避免多购买，单月多重置的bug