### PR TITLE
修复手残写的bug

### DIFF
--- a/src/Command/Job.php
+++ b/src/Command/Job.php
@@ -133,7 +133,7 @@ class Job extends Command
         }
 
         //auto reset
-        $boughts = Bought::whereIn('id', Bought::groupBy(userid)->where('renew','=','1')->max('id'));
+        $boughts = Bought::whereIn('id', Bought::groupBy('userid')->where('renew','=','1')->max('id'));
         $bought_users = array();
         foreach ($boughts as $bought) {
             $user = User::where('id', $bought->userid)->first();


### PR DESCRIPTION
有自己写入的/刚git clone的，麻烦自行修改一下
$boughts = Bought::whereIn('id', Bought::groupBy(userid)->where('renew','=','1')->max('id'));
替换
$boughts = Bought::whereIn('id', Bought::groupBy('userid')->where('renew','=','1')->max('id'));

groupBy 内应该有 ' '