### PR TITLE
Support Shadowsocks AEAD multiuser in a port

### DIFF
--- a/src/Models/Node.php
+++ b/src/Models/Node.php
@@ -241,8 +241,15 @@ class Node extends Model
             if ($mu_user == null) {
                 return null;
             }
-            $mu_user->obfs_param = $user->getMuMd5();
-            $mu_user->protocol_param = $user->id . ':' . $user->passwd;
+            // 如果混淆和协议均为SS原生且为单端口的，即判断为AEAD单端口类型，密码配置为用户自身密码
+            if ($mu_user->obfs == "plain" && $mu_user->protocol == "origin"){
+                $mu_user->passwd = $user->passwd;
+                $mu_user->obfs_param     = "";
+                $mu_user->protocol_param = "";
+            }else{
+                $mu_user->obfs_param = $user->getMuMd5();
+                $mu_user->protocol_param = $user->id . ':' . $user->passwd;
+            }
             $user = $mu_user;
             $node_name .= ($_ENV['disable_sub_mu_port'] ? '' : ' - ' . $mu_port . ' 单端口');
         }


### PR DESCRIPTION
AEAD单端口多用户无需协议混淆支持,设置承载用户时 协议设为"origin", 混淆设为"plain"即可支持AEAD单端口类型, 届时密码不再为单端口承载用户密码,故作此改动.