### PR TITLE
clash 已经支持ssr 了

### DIFF
--- a/src/Utils/AppURI.php
+++ b/src/Utils/AppURI.php
@@ -325,9 +325,9 @@ class AppURI
                     'cipher'          => $item['method'],
                     'password'        => $item['passwd'],
                     'protocol'        => $item['protocol'],
-                    'protocolparam'   => $item['protocol_param'],
+                    'protocol-param'   => $item['protocol_param'],
                     'obfs'            => $item['obfs'],
-                    'obfsparam'       => $item['obfs_param']
+                    'obfs-param'       => $item['obfs_param']
                 ];
                 break;
             case 'vmess':


### PR DESCRIPTION
https://github.com/paradiseduo/ClashXR/issues/24

```
Clash的SSR新参数与ClashR参数的区别在于 protocolparam 和 obfsparam 的不同
ClashR是「protocolparam」和「obfsparam」
Clash新参数是「protocol-param」和「obfs-param」
```