### PR TITLE
Fix non-standard v2rayN subscription links.

### DIFF
--- a/src/Utils/AppURI.php
+++ b/src/Utils/AppURI.php
@@ -57,12 +57,12 @@ class AppURI
         switch ($item['type']) {
             case 'vmess':
                 $node = [
-                    'v'     => 2,
+                    'v'     => "2",
                     'ps'    => $item['remark'],
                     'add'   => $item['add'],
-                    'port'  => $item['port'],
+                    'port'  => (string)$item['port'],
                     'id'    => $item['id'],
-                    'aid'   => $item['aid'],
+                    'aid'   => (string)$item['aid'],
                     'net'   => $item['net'],
                     'type'  => $item['headerType'],
                     'host'  => $item['host'],


### PR DESCRIPTION
修复了不标准的 v2rayN 订阅链接，[标准格式](https://github.com/2dust/v2rayN/wiki/%E5%88%86%E4%BA%AB%E9%93%BE%E6%8E%A5%E6%A0%BC%E5%BC%8F%E8%AF%B4%E6%98%8E(ver-2))

~~主要是适配 Netch 1.8.0~~