### PR TITLE
为surge节点增加sni参数

### DIFF
--- a/src/Utils/AppURI.php
+++ b/src/Utils/AppURI.php
@@ -102,7 +102,7 @@ class AppURI
                             break;
                         }
                         $tls = ($item['tls'] == 'tls'
-                            ? ', tls=true'
+                            ? ', tls=true, sni=' . $item['host']
                             : '');
                         $ws = ($item['net'] == 'ws'
                             ? ', ws=true, ws-path=' . $item['path'] . ', ws-headers=host:' . $item['host']


### PR DESCRIPTION
增加sni参数并使用host作为sni，防止在surge使用vmess tls节点时，由于节点证书与节点域名不一致导致的证书错误