### PR TITLE
缓解码支付错误

### DIFF
--- a/src/Services/Gateway/Codepay.php
+++ b/src/Services/Gateway/Codepay.php
@@ -85,7 +85,7 @@ class Codepay extends AbstractPayment
             $urls .= "$key=" . urlencode($val); //拼接为url参数形式并URL编码参数值
         }
         $query = $urls . '&sign=' . md5($sign . $codepay_key); //创建订单所需的参数
-        $url = 'https://codepay.fateqq.com/creat_order/?' . $query; //支付页面
+        $url = 'https://api5.xiuxiu888.com/creat_order/?' . $query; //支付页面
 
 
         header('Location:' . $url);


### PR DESCRIPTION
使用该接口后能成功加载二维码，但倒计时错误，姑且让码支付残废的用下去，，，