### PR TITLE
为vmess增加sni分流支持

### DIFF
--- a/src/Utils/AppURI.php
+++ b/src/Utils/AppURI.php
@@ -67,8 +67,10 @@ class AppURI
                     'type'  => $item['headerType'],
                     'host'  => $item['host'],
                     'path'  => $item['path'],
-                    'tls'   => $item['tls']
+                    'tls'   => $item['tls'],
+                    'sni'	=> $item['sni']
                 ];
+				
                 $return = ('vmess://' . base64_encode(
                     json_encode($node, 320)
                 ));
@@ -101,12 +103,16 @@ class AppURI
                         if (!in_array($item['net'], ['ws', 'tcp'])) {
                             break;
                         }
-                        $tls = ($item['tls'] == 'tls'
-                            ? ', tls=true, sni=' . $item['host']
-                            : '');
+                        $tls = ($item['tls'] == 'tls' 
+                                ? ', tls=true' ,sni=' . $item['host']
+                                : '');
+                        /*$sni = ($item['sni'] 
+                            ? ', '.$item['sni'] 
+                            : '');*/
                         $ws = ($item['net'] == 'ws'
                             ? ', ws=true, ws-path=' . $item['path'] . ', ws-headers=host:' . $item['host']
                             : '');
+                        #$return = $item['remark'] . ' = vmess, ' . $item['add'] . ', ' . $item['port'] . ', username = ' . $item['id'] . $ws . $tls . $sni; #未测试
                         $return = $item['remark'] . ' = vmess, ' . $item['add'] . ', ' . $item['port'] . ', username = ' . $item['id'] . $ws . $tls;
                         break;
                     case 'trojan':
@@ -339,6 +345,9 @@ class AppURI
                     'cipher'  => 'auto',
                     'udp'     => true
                 ];
+                if ($item['sni']) {
+                    $return['servername'] = $item['sni'];
+                }
                 if ($item['net'] == 'ws') {
                     $return['network'] = 'ws';
                     $return['ws-path'] = $item['path'];
@@ -424,9 +433,9 @@ class AppURI
                     if ($item['verify_cert'] == false) {
                         $tls .= '&allowInsecure=1';
                     }
-                    if (isset($item['localserver'])) {
-                        $tls .= '&peer=' . $item['localserver'];
-                    }
+                    $tls .= ($item['sni'] 
+                        ? ('&peer=' . $item['sni'])
+                        : ('&peer=' . $item['host']));
                 }
                 $return = ('vmess://' . Tools::base64_url_encode('auto:' . $item['id'] . '@' . $item['add'] . ':' . $item['port']) . '?remarks=' . rawurlencode($item['remark']) . $obfs . $tls . '&alterId=' . $item['aid']);
                 break;


### PR DESCRIPTION
支持clash Shadowrocket v2rayn 的sni证书功能
使用方法：节点地址 末尾添加 "|sni=证书域名"
如节点保存错误，是因为节点地址长度过长超过了默认的128字节导致的
数据库 执行
ALTER TABLE ss_node CHANGE server server VARCHAR(256) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL;