### PR TITLE
修复了webapi获取在线用户ip导致数据库占用过高的问题

### DIFF
--- a/src/Controllers/Mod_Mu/UserController.php
+++ b/src/Controllers/Mod_Mu/UserController.php
@@ -79,7 +79,7 @@ class UserController extends BaseController
                     }
                 )->orwhere('is_admin', 1);
             }
-        )->where('enable', 1)->where('expire_in', '>', date('Y-m-d H:i:s'))->get();
+        )->where('enable', 1)->where('expire_in', '>', date('Y-m-d H:i:s'))->withCount(['online_ip as alive_ip' => function($query) {$query->where('datetime', '>=', time() - 60);}])->get();
 
         $users = array();
 
@@ -94,13 +94,8 @@ class UserController extends BaseController
 
         $alive_ips = (new \App\Models\Ip)->getUserAliveIp();
         foreach ($users_raw as $user_raw) {
-            if ($user_raw->node_connector != 0) {
-                if (array_key_exists($user_raw->id, $alive_ips)) {
-                    $user_raw->alive_ip = $alive_ips[$user_raw->id]; # (new \App\Models\Ip)->getUserAliveIpCount($user_raw->id);
-                }
-                else {
-                    $user_raw->alive_ip = 0;
-                }
+            if ($user_raw->node_connector == 0) {
+                $user_raw->alive_ip = 0;
             }
             if ($user_raw->transfer_enable <= $user_raw->u + $user_raw->d) {
                 if ($_ENV['keep_connect'] === true) {

--- a/src/Controllers/Mod_Mu/UserController.php
+++ b/src/Controllers/Mod_Mu/UserController.php
@@ -92,9 +92,15 @@ class UserController extends BaseController
                 'is_multi_user', 'u', 'd', 'transfer_enable', 'id', 'port', 'passwd', 'node_connector', 'alive_ip');
         }
 
+        $alive_ips = (new \App\Models\Ip)->getUserAliveIp();
         foreach ($users_raw as $user_raw) {
             if ($user_raw->node_connector != 0) {
-                $user_raw->alive_ip = (new \App\Models\Ip)->getUserAliveIpCount($user_raw->id);
+                if (array_key_exists($user_raw->id, $alive_ips)) {
+                    $user_raw->alive_ip = $alive_ips[$user_raw->id]; # (new \App\Models\Ip)->getUserAliveIpCount($user_raw->id);
+                }
+                else {
+                    $user_raw->alive_ip = 0;
+                }
             }
             if ($user_raw->transfer_enable <= $user_raw->u + $user_raw->d) {
                 if ($_ENV['keep_connect'] === true) {

--- a/src/Models/Ip.php
+++ b/src/Models/Ip.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Utils\QQWry;
 use App\Utils\Tools;
+use Illuminate\Database\Capsule\Manager as Capsule;
 
 /**
  * Ip Model
@@ -81,9 +82,14 @@ class Ip extends Model
         return Node::where('node_ip', Tools::getRealIp($this->ip))->first() ? '是' : '否';
     }
 
-    public function getUserAliveIpCount($userid)
+    public function getUserAliveIp(): array
     {
-        return count(self::where('userid', '=', $userid)->where('datetime', '>=', time() - 60)->get());
+        $user_ips = array();
+        $alive_ips = Ip::select('userid', Capsule::raw('count(ip) as ip_count'))->where('datetime', '>=', time() - 60)->groupBy("userid")->get();
+        foreach ($alive_ips as $ip) {
+            $user_ips[$ip->userid] = $ip->ip_count;
+        }
+        return $user_ips;
     }
 
     public function ip()

--- a/src/Models/Ip.php
+++ b/src/Models/Ip.php
@@ -82,16 +82,6 @@ class Ip extends Model
         return Node::where('node_ip', Tools::getRealIp($this->ip))->first() ? '是' : '否';
     }
 
-    public function getUserAliveIp(): array
-    {
-        $user_ips = array();
-        $alive_ips = Ip::select('userid', Capsule::raw('count(ip) as ip_count'))->where('datetime', '>=', time() - 60)->groupBy("userid")->get();
-        foreach ($alive_ips as $ip) {
-            $user_ips[$ip->userid] = $ip->ip_count;
-        }
-        return $user_ips;
-    }
-
     public function ip()
     {
         return str_replace('::ffff:', '', $this->attributes['ip']);

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -444,6 +444,11 @@ class User extends Model
         return count($ip_list);
     }
 
+    public function online_ip()
+    {
+        return $this->hasMany(Ip::class, 'userid');
+    }
+
     /**
      * 销户
      */


### PR DESCRIPTION
#1264 
先查询最近一分钟所有在线用户id和对应ip返回，并保存成字典。之后只需判断用户ID是否存在于该字典。此时查询次数可以降为一次查询，减少数据库负担。