### PR TITLE
Gravatar头像地址改为未被墙的镜像地址

### DIFF
--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -61,7 +61,7 @@ class User extends Model
     public function getGravatarAttribute(): string
     {
         $hash = md5(strtolower(trim($this->email)));
-        return 'https://www.gravatar.com/avatar/' . $hash . '?&d=identicon';
+        return 'https://sdn.geekzu.org/avatar/' . $hash . '?&d=identicon';
     }
 
     /**


### PR DESCRIPTION
由于官方地址被墙，未使用代理访客无法加载头像导致页面加载缓慢，找了个没被墙的镜像地址，来源：https://zhuanlan.zhihu.com/p/115248957