### PR TITLE
add docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3'
+
+services:
+    sspanel:
+        image: sspaneluim/panel
+        container_name: sspanel
+        restart: always
+        ports:
+            - 80:80
+        volumes:
+            - ./config/.config.php:/var/www/config/.config.php
+    mariadb:
+        image: mariadb:10.6
+        container_name: mariadb
+        restart: always
+        environment:
+          MYSQL_ROOT_PASSWORD: sspanel
+
+    phpmyadmin:
+        image: phpmyadmin
+        container_name: phpmyadmin
+        restart: always
+        ports:
+          - 8080:80
+        environment:
+          - PMA_ARBITRARY=1


### PR DESCRIPTION
由于没有了演示站点，有时候想看看最新面板增加的功能或者测试bug，搭建往往浪费了很多时间。
增加docker-compose.yml，让搭建面板更简单。