### PR TITLE
修复支付同步异常

### DIFF
--- a/app/routes.php
+++ b/app/routes.php
@@ -107,7 +107,7 @@ return function (SlimApp $app) {
     $app->group('/payment', function () {
         $this->get('/notify/{type}',           App\Services\Payment::class . ':notify');
         $this->post('/notify/{type}',   App\Services\Payment::class . ':notify');
-        $this->post('/status',          App\Services\Payment::class . ':getStatus');
+        $this->post('/status/{type}',          App\Services\Payment::class . ':getStatus');
         // $this->post('/coinpay/notify',  App\Services\CoinPayment::class. ':notify');
     });
 


### PR DESCRIPTION
支付同步回调返回404 ( 少了"{type}"