### PR TITLE
恢复clash的旧版格式，使其并行

### DIFF
--- a/src/Utils/AppURI.php
+++ b/src/Utils/AppURI.php
@@ -366,6 +366,8 @@ class AppURI
                     $return['network'] = 'ws';
                     $return['ws-opts']['path'] = $item['path'];
                     $return['ws-opts']['headers']['Host'] = ($item['host'] != '' ? $item['host'] : $item['add']);
+                    $return['ws-path'] = $item['path'];
+                    $return['ws-headers']['Host'] = ($item['host'] != '' ? $item['host'] : $item['add']);
                 }
                 if ($item['tls'] == 'tls') {
                     $return['tls'] = true;


### PR DESCRIPTION
可以并存，为何移除？迷惑行为