### PR TITLE
Add back parseArgs to fix bug

### DIFF
--- a/src/Utils/Tools.php
+++ b/src/Utils/Tools.php
@@ -536,8 +536,9 @@ final class Tools
                         break;
                 }
             }
-        }
-        if (count($server) >= 5) {
+            if (count($server) >= 6 && $server[5] !== '') {
+                $item = array_merge($item, URL::parseArgs($server[5]));
+            }
             $item = array_merge($item, $node->getArgs());
             if (array_key_exists('server', $item)) {
                 $item['add'] = $item['server'];
@@ -619,8 +620,9 @@ final class Tools
             } elseif ($server[4] === 'tls') {
                 $item['tls'] = 'tls';
             }
-        }
-        if (count($server) >= 5) {
+            if (count($server) >= 6 && $server[5] !== '') {
+                $item = array_merge($item, URL::parseArgs($server[5]));
+            }
             $item = array_merge($item, $node->getArgs());
             if (array_key_exists('server', $item)) {
                 $item['add'] = $item['server'];
@@ -635,6 +637,7 @@ final class Tools
                 unset($item['outside_port']);
             }
         }
+
         if ($item['net'] === 'obfs') {
             if (stripos($server[4], 'http') !== false) {
                 $item['obfs'] = 'simple_obfs_http';

--- a/src/Utils/URL.php
+++ b/src/Utils/URL.php
@@ -72,6 +72,24 @@ final class URL
         return 3;
     }
 
+    /**
+     * parse xxx=xxx|xxx=xxx to array(xxx => xxx, xxx => xxx)
+     */
+    public static function parseArgs(string $origin): array
+    {
+        // parse xxx=xxx|xxx=xxx to array(xxx => xxx, xxx => xxx)
+        $args_explode = explode('|', $origin);
+
+        $return_array = [];
+        foreach ($args_explode as $arg) {
+            $split_point = strpos($arg, '=');
+
+            $return_array[substr($arg, 0, $split_point)] = substr($arg, $split_point + 1);
+        }
+
+        return $return_array;
+    }
+
     public static function SSCanConnect(User $user, $mu_port = 0): bool
     {
         if ($mu_port !== 0) {


### PR DESCRIPTION
很多人还在使用把参数写在节点地址server[5]的方式，在commit：https://github.com/Anankke/SSPanel-Uim/commit/8d677b61aed5420686f9f9dbfbebe16bd7d1c481 将v2ray中的全部parseArgs改为custom config会导致很多path下发为“/”的问题：
- https://github.com/Anankke/SSPanel-Uim/issues/1497
- https://github.com/Anankke/SSPanel-Uim/issues/1517