### PR TITLE
【bug】严格判断零值导致报错

### DIFF
--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -206,7 +206,7 @@ final class User extends Model
      */
     public function trafficUsagePercent(): int
     {
-        if ($this->transfer_enable === 0) {
+        if ($this->transfer_enable == 0) {
             return 0;
         }
         $percent = ($this->u + $this->d) / $this->transfer_enable;
@@ -227,7 +227,7 @@ final class User extends Model
      */
     public function unusedTrafficPercent(): float
     {
-        if ($this->transfer_enable === 0) {
+        if ($this->transfer_enable == 0) {
             return 0;
         }
         $unused = $this->transfer_enable - ($this->u + $this->d);
@@ -249,7 +249,7 @@ final class User extends Model
      */
     public function todayUsedTrafficPercent(): float
     {
-        if ($this->transfer_enable === 0 || $this->transfer_enable === '0' || $this->transfer_enable === null) {
+        if ($this->transfer_enable == 0 || $this->transfer_enable === '0' || $this->transfer_enable === null) {
             return 0;
         }
         $Todayused = $this->u + $this->d - $this->last_day_t;
@@ -271,7 +271,7 @@ final class User extends Model
      */
     public function lastUsedTrafficPercent(): float
     {
-        if ($this->transfer_enable === 0 || $this->transfer_enable === '0' || $this->transfer_enable === null) {
+        if ($this->transfer_enable == 0 || $this->transfer_enable === '0' || $this->transfer_enable === null) {
             return 0;
         }
         $Lastused = $this->last_day_t;


### PR DESCRIPTION
所有过期的用户无法登录面板，发现没有正确判断零值，Division by zero error