### PR TITLE
Change Telegram unbind button and  change all .on('click') in ajax to .off('click').on('click') 

### DIFF
--- a/resources/views/tabler/admin/announcement/index.tpl
+++ b/resources/views/tabler/admin/announcement/index.tpl
@@ -102,7 +102,7 @@
         function deleteAnn(ann_id) {
             $('#notice-message').text('确定删除此公告？');
             $('#notice-dialog').modal('show');
-            $('#notice-confirm').on('click', function() {
+            $('#notice-confirm').off('click').on('click', function() {
                 $.ajax({
                     url: "/admin/announcement/" + ann_id,
                     type: 'DELETE',

--- a/resources/views/tabler/admin/coupon.tpl
+++ b/resources/views/tabler/admin/coupon.tpl
@@ -196,7 +196,7 @@
         function deleteCoupon(coupon_id) {
             $('#notice-message').text('确定删除此优惠码？');
             $('#notice-dialog').modal('show');
-            $('#notice-confirm').on('click', function() {
+            $('#notice-confirm').off('click').on('click', function() {
                 $.ajax({
                     url: "/admin/coupon/" + coupon_id,
                     type: 'DELETE',
@@ -218,7 +218,7 @@
         function disableCoupon(coupon_id) {
             $('#notice-message').text('确定禁用此优惠码？');
             $('#notice-dialog').modal('show');
-            $('#notice-confirm').on('click', function() {
+            $('#notice-confirm').off('click').on('click', function() {
                 $.ajax({
                     url: "/admin/coupon/" + coupon_id + "/disable",
                     type: 'POST',

--- a/resources/views/tabler/admin/detect.tpl
+++ b/resources/views/tabler/admin/detect.tpl
@@ -169,7 +169,7 @@
         function deleteRule(rule_id) {
             $('#notice-message').text('确定删除此审计规则？');
             $('#notice-dialog').modal('show');
-            $('#notice-confirm').on('click', function() {
+            $('#notice-confirm').off('click').on('click', function() {
                 $.ajax({
                     url: "/admin/detect/" + rule_id,
                     type: 'DELETE',

--- a/resources/views/tabler/admin/giftcard.tpl
+++ b/resources/views/tabler/admin/giftcard.tpl
@@ -176,7 +176,7 @@
         function deleteGiftCard(giftcard_id) {
             $('#notice-message').text('确定删除此礼品卡？');
             $('#notice-dialog').modal('show');
-            $('#notice-confirm').on('click', function() {
+            $('#notice-confirm').off('click').on('click', function() {
                 $.ajax({
                     url: "/admin/giftcard/" + giftcard_id,
                     type: 'DELETE',

--- a/resources/views/tabler/admin/node/index.tpl
+++ b/resources/views/tabler/admin/node/index.tpl
@@ -104,7 +104,7 @@
         function deleteNode(node_id) {
             $('#notice-message').text('确定删除此节点？');
             $('#notice-dialog').modal('show');
-            $('#notice-confirm').on('click', function() {
+            $('#notice-confirm').off('click').on('click', function() {
                 $.ajax({
                     url: "/admin/node/" + node_id,
                     type: 'DELETE',
@@ -126,7 +126,7 @@
         function copyNode(node_id) {
             $('#notice-message').text('确定复制此节点？');
             $('#notice-dialog').modal('show');
-            $('#notice-confirm').on('click', function() {
+            $('#notice-confirm').off('click').on('click', function() {
                 $.ajax({
                     url: "/admin/node/" + node_id + "/copy",
                     type: 'POST',

--- a/resources/views/tabler/admin/order/index.tpl
+++ b/resources/views/tabler/admin/order/index.tpl
@@ -94,7 +94,7 @@
         function deleteOrder(order_id) {
             $('#notice-message').text('确定删除此订单？');
             $('#notice-dialog').modal('show');
-            $('#notice-confirm').on('click', function() {
+            $('#notice-confirm').off('click').on('click', function() {
                 $.ajax({
                     url: "/admin/order/" + order_id,
                     type: 'DELETE',
@@ -116,7 +116,7 @@
         function cancelOrder(order_id) {
             $('#notice-message').text('确定取消此订单？');
             $('#notice-dialog').modal('show');
-            $('#notice-confirm').on('click', function() {
+            $('#notice-confirm').off('click').on('click', function() {
                 $.ajax({
                     url: "/admin/order/" + order_id + "/cancel",
                     type: 'POST',

--- a/resources/views/tabler/admin/product/index.tpl
+++ b/resources/views/tabler/admin/product/index.tpl
@@ -102,7 +102,7 @@
         function deleteProduct(product_id) {
             $('#notice-message').text('确定删除此产品？');
             $('#notice-dialog').modal('show');
-            $('#notice-confirm').on('click', function() {
+            $('#notice-confirm').off('click').on('click', function() {
                 $.ajax({
                     url: "/admin/product/" + product_id,
                     type: 'DELETE',
@@ -124,7 +124,7 @@
         function copyProduct(product_id) {
             $('#notice-message').text('确定复制此产品？');
             $('#notice-dialog').modal('show');
-            $('#notice-confirm').on('click', function() {
+            $('#notice-confirm').off('click').on('click', function() {
                 $.ajax({
                     url: "/admin/product/" + product_id + "/copy",
                     type: 'POST',

--- a/resources/views/tabler/admin/ticket/index.tpl
+++ b/resources/views/tabler/admin/ticket/index.tpl
@@ -94,7 +94,7 @@
         function closeTicket(ticket_id) {
             $('#notice-message').text('确定关闭此工单？');
             $('#notice-dialog').modal('show');
-            $('#notice-confirm').on('click', function () {
+            $('#notice-confirm').off('click').on('click', function () {
                 $.ajax({
                     url: "/admin/ticket/" + ticket_id + '/close',
                     type: 'PUT',
@@ -116,7 +116,7 @@
         function deleteTicket(ticket_id) {
             $('#notice-message').text('确定删除此工单？');
             $('#notice-dialog').modal('show');
-            $('#notice-confirm').on('click', function() {
+            $('#notice-confirm').off('click').on('click', function() {
                 $.ajax({
                     url: "/admin/ticket/" + ticket_id,
                     type: 'DELETE',

--- a/resources/views/tabler/admin/user/index.tpl
+++ b/resources/views/tabler/admin/user/index.tpl
@@ -175,7 +175,7 @@
         function deleteUser(user_id) {
             $('#notice-message').text('确定删除此用户？');
             $('#notice-dialog').modal('show');
-            $('#notice-confirm').on('click', function() {
+            $('#notice-confirm').off('click').on('click', function() {
                 $.ajax({
                     url: "/admin/user/" + user_id,
                     type: 'DELETE',

--- a/resources/views/tabler/user/edit.tpl
+++ b/resources/views/tabler/user/edit.tpl
@@ -151,8 +151,10 @@
                                                 </div>
                                                 <div class="card-footer">
                                                     <div class="d-flex">
-                                                        <a href="/user/telegram_reset"
-                                                            class="btn btn-red ms-auto">解绑</a>
+                                                       <button id="unbind-telegram-btn" 
+                                                            class="btn btn-red ms-auto">
+                                                            解绑
+                                                       </button>
                                                     </div>
                                                 </div>
                                             </div>
@@ -779,7 +781,26 @@
                 }
             })
         });
-        
+        $("#unbind-telegram-btn").click(function() {
+          $.ajax({
+            type: "POST",
+            url: "/user/telegram_reset",
+            dataType: "json",
+            success: function(data) {
+              if (data.ret === 1) {
+                $('#success-message').text(data.msg);
+                $('#success-dialog').modal('show');
+                setTimeout(function() {
+                  location.reload();
+                }, 1000);
+              } else {
+                $('#fail-message').text(data.msg);
+                $('#fail-dialog').modal('show');
+              }
+            }
+          })
+        });
+
         {if $config['enable_kill']}
         $("#confirm-destroy").click(function() {
             $.ajax({


### PR DESCRIPTION
- Change all .on('click') to .off('click').on('click') 
    Change all `.on('click')` to `.off('click').on('click')` for proper event unbinding and to prevent issues with duplicate event handlers.

    `.on('click')` 调用后没有解除绑定，也没有刷新页面，因此会导致下一次进行同样操作的时候出现发送以前和现在的全部请求。因此使用 `.off('click')`解除绑定。
    此问题导致曾经的实际可感知的影响应该为前端（节点、产品）的时候，连续复制会出现问题，其他删除、停用因为在重复发送ajax请求的时候已经操作过了，所以可能没有被感知。

- 修改 edit.tpl
    由于 `/user/telegram_reset` 不支持GET方式，因此使用AJAX进行解绑处理。
