### PR TITLE
修复关于随机节点组的bug。

### DIFF
--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -325,7 +325,7 @@ final class AuthController extends BaseController
         if ($random_group === '') {
             $user->node_group = 0;
         } else {
-            $user->node_group = $random_group[array_rand(explode(',', $random_group))];
+            $user->node_group = explode(',', $random_group)[array_rand(explode(',', $random_group))];
         }
 
         if ($user->save() && ! $is_admin_reg) {

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -422,7 +422,11 @@ final class AuthController extends BaseController
         try {
             return $this->registerHelper($response, $name, $email, $passwd, $code, $imtype, $imvalue, 0, 0, 0);
         } catch (Exception $e) {
-            return ResponseHelper::error($response, $e->getMessage());
+            if ($_ENV['debug']) {
+                return ResponseHelper::error($response, $e->getMessage());
+            } else {
+                return ResponseHelper::error($response, '系统错误');
+            }
         }
     }
 

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -424,9 +424,8 @@ final class AuthController extends BaseController
         } catch (Exception $e) {
             if ($_ENV['debug']) {
                 return ResponseHelper::error($response, $e->getMessage());
-            } else {
-                return ResponseHelper::error($response, '系统错误');
-            }
+            } 
+            return ResponseHelper::error($response, '系统错误');
         }
     }
 

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -424,7 +424,7 @@ final class AuthController extends BaseController
         } catch (Exception $e) {
             if ($_ENV['debug']) {
                 return ResponseHelper::error($response, $e->getMessage());
-            } 
+            }
             return ResponseHelper::error($response, '系统错误');
         }
     }


### PR DESCRIPTION
1. 修复在生成随机节点组时出现的 
  **表现：** 
  注册时随机出现 SQL 错误 
    ```
    Incorrect integer value:, for column 
    ```
   **原因：**
   `explode` 将`$random_group`字符串拆为数组后随机生成了位置，但是下一步是在这个字符串中对该位置进行查找，因此会出现`"1,2,3"`中找到了第[1]项，因此返回了字符串的半角逗号的情况。
   **可能依然存在的问题（未测试和更改）：**
   如果只存在逗号，或者在后台填写的内容不规范，仍然有可能存在问题。例如插入时候出现了空格等
2. 隐藏该问题直接输出 SQL 错误语句。
