### PR TITLE
Fix subscription on clash, legacy v2ray link and order activation

### DIFF
--- a/src/Controllers/LinkController.php
+++ b/src/Controllers/LinkController.php
@@ -206,9 +206,9 @@ final class LinkController extends BaseController
                 $network = $node_custom_config['network'] ?? '';
                 $header = $node_custom_config['header'] ?? ['type' => 'none'];
                 $header_type = $header['type'] ?? '';
-                $host = $node_custom_config['host'] ?? '';
-                $path = $node_custom_config['path'] ?? '/';
-
+                $host = $node_custom_config['header']['request']['headers']['Host'][0] ?? $node_custom_config['host'] ?? '';
+                $path = $node_custom_config['header']['request']['path'][0] ?? $node_custom_config['path'] ?? '/';
+                
                 $v2rayn_array = [
                     'v' => '2',
                     'ps' => $node_raw->name,

--- a/src/Controllers/SubController.php
+++ b/src/Controllers/SubController.php
@@ -115,9 +115,9 @@ final class SubController extends BaseController
                     $network = $node_custom_config['network'] ?? '';
                     $header = $node_custom_config['header'] ?? ['type' => 'none'];
                     $header_type = $header['type'] ?? '';
-                    $host = $node_custom_config['host'] ?? '';
+                    $host = $node_custom_config['header']['request']['headers']['Host'][0] ?? $node_custom_config['host'] ?? '';
                     $servicename = $node_custom_config['servicename'] ?? '';
-                    $path = $node_custom_config['path'] ?? '/';
+                    $path = $node_custom_config['header']['request']['path'][0] ?? $node_custom_config['path'] ?? '/';
                     $tls = in_array($security, ['tls', 'xtls']) ? '1' : '0';
                     $enable_vless = $node_custom_config['enable_vless'] ?? '0';
                     $node = [
@@ -257,8 +257,8 @@ final class SubController extends BaseController
                     $alter_id = $node_custom_config['alter_id'] ?? '0';
                     $security = $node_custom_config['security'] ?? 'none';
                     $encryption = $node_custom_config['encryption'] ?? 'auto';
-                    $network = $node_custom_config['network'] ?? '';
-                    $host = $node_custom_config['host'] ?? '';
+                    $network = $node_custom_config['header']['type'] ?? $node_custom_config['network'] ?? '';
+                    $host = $node_custom_config['header']['request']['headers']['Host'][0] ?? $node_custom_config['host'] ?? '';
                     $allow_insecure = $node_custom_config['allow_insecure'] ?? false;
                     $tls = in_array($security, ['tls', 'xtls']);
                     // Clash 特定配置


### PR DESCRIPTION
1.对于clash，使用 v2ray tcp+http 时，无法正确下发订阅中的 network 类型为 http
2.对于传统 v2ray 订阅，使用 v2ray tcp+http 时，无法正确解析和下发 costom config 中的 host 项和 path 项
3.新商店系统订单激活机制存在设计缺陷，时间流量包若时间未到而流量提前用完则无法激活「待激活」订单；修改了判断账单是否过期的判断条件，等级过期/流量用完均会触发原账单进入过期状态
4.cronjob 流程顺序设计缺陷，先激活等待激活的账单而后判断是否有订单过期，导致原订单达到过期条件后需要两个cron周期才能激活新账单；修改将判断账单是否过期的代码移动至激活账单前，并且判断过期后再执行一次查询已激活账单的语句以更新状态