### PR TITLE
Update 2023060300-add_user_locale_and_update_data_type.php

### DIFF
--- a/db/migrations/2023060300-add_user_locale_and_update_data_type.php
+++ b/db/migrations/2023060300-add_user_locale_and_update_data_type.php
@@ -55,7 +55,7 @@ return new class() implements MigrationInterface {
         ALTER TABLE user MODIFY COLUMN `use_new_shop` tinyint(1) NOT NULL DEFAULT 0 COMMENT '是否启用新商店';
         ALTER TABLE user MODIFY COLUMN `is_dark_mode` tinyint(1) NOT NULL DEFAULT 0;
         ALTER TABLE user DROP KEY IF EXISTS `user_name`;
-        ALTER TABLE user ADD UNIQUE KEY `api_token` (`api_token`);
+        ALTER TABLE user ADD UNIQUE KEY IF NOT EXISTS `api_token` (`api_token`);
         ALTER TABLE user ADD KEY IF NOT EXISTS `is_admin` (`is_admin`);
         ALTER TABLE user ADD KEY IF NOT EXISTS `is_banned` (`is_banned`);
         ALTER TABLE user CHANGE COLUMN IF EXISTS `sendDailyMail` `daily_mail_enable` tinyint(1) NOT NULL DEFAULT 0 COMMENT '每日报告开关';


### PR DESCRIPTION
修复BUG，BUG复现:
执行命令:
php xcat Migration new

BUG提示:
Current database version 0.

Found migration version 2023060300.
Found migration version 2023031701.
Found migration version 2023020100.
Found migration version 2023021600.
Found migration version 2023030500.
Found migration version 2023032600.
Found migration version 2023031700.
Found migration version 2023053000.
Found migration version 2023050800.

Forward to 2023020100
Forward to 2023021600
Forward to 2023030500
Forward to 2023031700
Forward to 2023031701
Forward to 2023032600
Forward to 2023050800
Forward to 2023053000
Forward to 2023060300
PHP Fatal error:  Uncaught PDOException: SQLSTATE[42000]: Syntax error or access violation: 1061 Duplicate key name 'api_token' in /usr/share/nginx/html/db/migrations/2023060300-add_user_locale_and_update_data_type.php:11 Stack trace:
#0 /usr/share/nginx/html/db/migrations/2023060300-add_user_locale_and_update_data_type.php(11): PDO->exec() #1 /usr/share/nginx/html/src/Command/Migration.php(103): App\Interfaces\MigrationInterface@anonymous->up() #2 /usr/share/nginx/html/xcat(50): App\Command\Migration->boot() #3 {main}
  thrown in /usr/share/nginx/html/db/migrations/2023060300-add_user_locale_and_update_data_type.php on line 11