### PR TITLE
Update SES to use AWS SESv2 & Add Sender Name

### DIFF
--- a/config/settings.json
+++ b/config/settings.json
@@ -641,6 +641,16 @@
     },
     {
         "id": null,
+        "item": "aws_ses_name",
+        "value": "",
+        "class": "aws_ses",
+        "is_public": 0,
+        "type": "string",
+        "default": "",
+        "mark": "aws ses发件人名称"
+    },	
+    {
+        "id": null,
         "item": "enable_telegram",
         "value": "0",
         "class": "telegram",

--- a/resources/views/tabler/admin/setting/email.tpl
+++ b/resources/views/tabler/admin/setting/email.tpl
@@ -279,6 +279,12 @@
                                         <input id="aws_ses_sender" type="text" class="form-control" value="{$settings['aws_ses_sender']}">
                                     </div>
                                 </div>
+                                <div class="form-group mb-3 row">
+                                    <label class="form-label col-3 col-form-label">AWS SES 发件人名称</label>
+                                    <div class="col">
+                                        <input id="aws_ses_name" type="text" class="form-control" value="{$settings['aws_ses_name']}">
+                                    </div>
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/src/Controllers/Admin/Setting/EmailController.php
+++ b/src/Controllers/Admin/Setting/EmailController.php
@@ -42,6 +42,7 @@ final class EmailController extends BaseController
         'aws_secret_access_key',
         'aws_region',
         'aws_ses_sender',
+        'aws_ses_name',    
         // Postal
         'postal_host',
         'postal_key',

--- a/src/Services/Mail/Ses.php
+++ b/src/Services/Mail/Ses.php
@@ -5,17 +5,17 @@ declare(strict_types=1);
 namespace App\Services\Mail;
 
 use App\Models\Setting;
-use Aws\Ses\SesClient;
+use Aws\SesV2\SesV2Client;
 
 final class Ses extends Base
 {
-    private SesClient $ses;
+    private SesV2Client $ses;
 
     public function __construct()
     {
         $configs = Setting::getClass('aws_ses');
 
-        $ses = new SesClient([
+        $ses = new SesV2Client([
             'credentials' => [
                 'key' => $configs['aws_access_key_id'],
                 'secret' => $configs['aws_secret_access_key'],
@@ -36,24 +36,25 @@ final class Ses extends Base
             'Destination' => [
                 'ToAddresses' => [$to],
             ],
-            'Source' => Setting::obtain('aws_ses_sender'),
-            'Message' => [
-                'Body' => [
-                    'Html' => [
-                        'Charset' => $char_set,
-                        'Data' => $text,
+            'FromEmailAddress' => Setting::obtain('aws_ses_sender'),
+            'Content' => [                        
+                'Simple' => [
+                    'Body' => [
+                        'Html' => [
+                            'Charset' => $char_set,
+                            'Data' => $text,
+                        ],
+                        'Text' => [
+                            'Charset' => $char_set,
+                            'Data' => $text,
+                        ],
                     ],
-                    'Text' => [
+                    'Subject' => [
                         'Charset' => $char_set,
-                        'Data' => $text,
+                        'Data' => $subject,
                     ],
-                ],
-                'Subject' => [
-                    'Charset' => $char_set,
-                    'Data' => $subject,
                 ],
             ],
-
         ]);
     }
 }


### PR DESCRIPTION
改了下AWS SES用的库，把以前指向于SES的更新到SESv2了
另外尝试给AWS SES添加发送人名称， 但是好像不太顺利…… 保存会弹500 （但是没看到日志）。 如果大佬们能帮忙看一下的话感激不尽
如果保存能弄好的话， 下一步应该就可以直接在 `src/Services/Mail/Ses.php` 里面加一个判断语句， 然后base64 encode 发送人名称塞进`FromEmailAddress`里面

Fix #2154 