### PR TITLE
fix the hash algorithm of epay to md5

### DIFF
--- a/src/Services/Gateway/Epay/EpayTool.php
+++ b/src/Services/Gateway/Epay/EpayTool.php
@@ -13,13 +13,13 @@ final class EpayTool
     {
         $prestr .= $key;
 
-        return hash('sha256', $prestr);
+        return hash('md5', $prestr);
     }
 
     public static function verify($prestr, $sign, $key): bool
     {
         $prestr .= $key;
-        $correct_sgin = hash('sha256', $prestr);
+        $correct_sgin = hash('md5', $prestr);
 
         return $correct_sgin === $sign;
     }


### PR DESCRIPTION
The signature verification mode of epay is md5