### PR TITLE
fix: unable to pass odd number to genRandomChar

### DIFF
--- a/src/Utils/Tools.php
+++ b/src/Utils/Tools.php
@@ -186,7 +186,8 @@ final class Tools
             $length = 2;
         }
 
-        return bin2hex(openssl_random_pseudo_bytes($length / 2));
+        $randomString = bin2hex(openssl_random_pseudo_bytes((int)ceil($length / 2)));
+        return substr($randomString, 0, $length);
     }
 
     public static function genSs2022UserPk(string $passwd, string $method): string|false

--- a/src/Utils/Tools.php
+++ b/src/Utils/Tools.php
@@ -186,7 +186,7 @@ final class Tools
             $length = 2;
         }
 
-        $randomString = bin2hex(openssl_random_pseudo_bytes((int)ceil($length / 2)));
+        $randomString = bin2hex(openssl_random_pseudo_bytes((int) ceil($length / 2)));
         return substr($randomString, 0, $length);
     }
 


### PR DESCRIPTION
传入奇数长度时会导致除以2结果为小数，产生以下报错
`openssl_random_pseudo_bytes(): Argument #1 ($length) must be of type int, float given`
解决方案：向上取整再截取字符串