### PR TITLE
[Uim] Add Rule (for ipv6)

### DIFF
--- a/config/appprofile.example.php
+++ b/config/appprofile.example.php
@@ -57,15 +57,17 @@ $_ENV['SingBox_Config'] = [
                 'detour' => 'direct',
             ],
             [
-                'tag' => 'proxy-v6',
-                'address' => 'tls://[2606:4700:4700::1111]',
-                'strategy' => 'prefer_ipv6',
-                'detour' => 'select',
+                'tag' => 'resolver',
+                'address' => 'quic://223.6.6.6',
+                'strategy' => 'ipv4_only',
+                'detour' => 'direct',
             ],
             [
-                'tag' => 'proxy-v4',
-                'address' => 'tls://1.1.1.1',
-                'strategy' => 'prefer_ipv4',
+                'tag' => 'cloudflare',
+                'address' => 'tls://one.one.one.one',
+                'address_resolver' => 'resolver',
+                'address_strategy' => 'ipv4_only',
+                'strategy' => 'prefer_ipv6',
                 'detour' => 'select',
             ],
             [
@@ -80,26 +82,18 @@ $_ENV['SingBox_Config'] = [
             ],
             [
                 'clash_mode' => 'Global',
-                'server' => 'proxy-v4',
-            ],
-            [
-                'clash_mode' => 'Global-v6',
-                'server' => 'proxy-v6',
+                'server' => 'cloudflare',
             ],
             [
                 'rule_set' => 'geosite-cn',
                 'server' => 'local',
             ],
             [
-                'clash_mode' => 'Rule-v6',
-                'server' => 'proxy-v6',
-            ],
-            [
                 'clash_mode' => 'Direct',
                 'server' => 'local',
             ],
         ],
-        'final' => 'proxy-v4',
+        'final' => 'cloudflare',
         'disable_cache' => true,
         'independent_cache' => true,
     ],
@@ -167,19 +161,11 @@ $_ENV['SingBox_Config'] = [
                 'outbound' => 'select',
             ],
             [
-                'clash_mode' => 'Global-v6',
-                'outbound' => 'select',
-            ],
-            [
                 'rule_set' => [
                     'geosite-cn',
                     'geoip-cn',
                 ],
                 'outbound' => 'direct',
-            ],
-            [
-                'clash_mode' => 'Rule-v6',
-                'outbound' => 'select',
             ],
             [
                 'protocol' => 'stun',

--- a/config/appprofile.example.php
+++ b/config/appprofile.example.php
@@ -87,11 +87,15 @@ $_ENV['SingBox_Config'] = [
                 'server' => 'proxy-v6',
             ],
             [
-                'clash_mode' => 'Direct',
+                'rule_set' => 'geosite-cn',
                 'server' => 'local',
             ],
             [
-                'rule_set' => 'geosite-cn',
+                'clash_mode' => 'Rule-v6',
+                'server' => 'proxy-v6',
+            ],
+            [
+                'clash_mode' => 'Direct',
                 'server' => 'local',
             ],
         ],
@@ -167,19 +171,22 @@ $_ENV['SingBox_Config'] = [
                 'outbound' => 'select',
             ],
             [
+                'rule_set' => [
+                    'geosite-cn',
+                    'geoip-cn',
+                ],
+                'outbound' => 'direct',
+            ],
+            [
+                'clash_mode' => 'Rule-v6',
+                'outbound' => 'select',
+            ],
+            [
                 'protocol' => 'stun',
                 'outbound' => 'block',
             ],
             [
                 'ip_is_private' => true,
-                'outbound' => 'direct',
-            ],
-            [
-                'rule_set' => 'geoip-cn',
-                'outbound' => 'direct',
-            ],
-            [
-                'rule_set' => 'geosite-cn',
                 'outbound' => 'direct',
             ],
         ],


### PR DESCRIPTION
sing-box很奇怪的故障，经测试 DNS Server `"address": "",` 使用域名且 `"address_resolver": "",` 正常配置的情况下，dot/h域名只能正常使用 DNSPod 系（如`dns.pub` `dot.pub`）的域名，其他家的dot/h服务（如`cloudflare` `google` `alidns`）域名（能解析到dot/h服务对应的IP）都无法使用解析服务（但直接使用dot/h服务 `IP` 可以正常使用解析服务）