### PR TITLE
refactor: display sequential audit rule IDs

### DIFF
--- a/resources/views/tabler/user/detect/index.tpl
+++ b/resources/views/tabler/user/detect/index.tpl
@@ -33,9 +33,9 @@
                                 </tr>
                                 </thead>
                                 <tbody>
-                                {foreach $rules as $rule}
+                                {foreach $rules as $index => $rule}
                                     <tr>
-                                        <td>#{$rule->id}</td>
+                                        <td>#{$index+1}</td>
                                         <td>{$rule->name}</td>
                                         <td>{$rule->text}</td>
                                         <td>{$rule->regex}</td>


### PR DESCRIPTION
Replaced the existing audit rule ID display with sequential numbering to avoid gaps in the IDs when rules are deleted.
The displayed ID now reflects the rule's position in the list, starting from 1 for the first rule, 2 for the second, and so on.