### PR TITLE
refactor(queue): 重构队列系统

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,8 @@
         "twig/twig": "^3",
         "vectorface/googleauthenticator": "^3",
         "voku/anti-xss": "^4",
-        "web-auth/webauthn-framework": "^5.2"
+        "web-auth/webauthn-framework": "^5.2",
+        "ext-pcntl": "*"
     },
     "autoload": {
         "psr-4": {

--- a/config/.config.example.php
+++ b/config/.config.example.php
@@ -44,6 +44,7 @@ $_ENV['redis_username'] = '';         // Redis用户名，留空则不使用用�
 $_ENV['redis_password'] = '';         // Redis密码，留空则无密码
 $_ENV['redis_ssl'] = false;           // 是否使用SSL连接Redis，如果使用了SSL，那么Redis端口应为Redis实例的TLS端口
 $_ENV['redis_ssl_context'] = [];      // 使用SSL时的上下文选项，参考 https://www.php.net/manual/zh/context.ssl.php
+$_ENV['enable_redis_queue'] = false;
 
 //Rate Limit 设置--------------------------------------------------------------------------------------------------------
 $_ENV['enable_rate_limit'] = true;     // 是否开启请求限制

--- a/src/Command/Queue.php
+++ b/src/Command/Queue.php
@@ -68,9 +68,6 @@ EOL;
     {
         $options = $this->parseOptions(array_slice($this->argv, 3));
 
-        // 解析队列参数
-        $queuesString = $options['queue'] ?? 'default';
-        $queues = array_map('trim', explode(',', $queuesString));
 
         // 验证队列名称
         $validQueues = [
@@ -79,10 +76,15 @@ EOL;
             RedisQueue::QUEUE_NOTIFICATION,
             RedisQueue::QUEUE_HIGH,
         ];
-
-        foreach ($queues as $queue) {
-            if (!in_array($queue, $validQueues, true)) {
-                echo "警告: 队列 '{$queue}' 不是预定义队列，但仍会监听" . PHP_EOL;
+        if (!isset($options['queue'])) {
+            $queues = $validQueues;
+        } else {
+            $queuesString = $options['queue'];
+            $queues = array_map('trim', explode(',', $queuesString));
+            foreach ($queues as $queue) {
+                if (!in_array($queue, $validQueues, true)) {
+                    echo "警告: 队列 '{$queue}' 不是预定义队列，但仍会监听" . PHP_EOL;
+                }
             }
         }
 

--- a/src/Command/Queue.php
+++ b/src/Command/Queue.php
@@ -1,0 +1,273 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Services\DB;
+use App\Services\Queue\Jobs\SendEmailJob;
+use App\Services\Queue\RedisQueue;
+use App\Services\Queue\Worker;
+use App\Utils\Tools;
+use function array_slice;
+use function count;
+use function in_array;
+use function is_numeric;
+use function method_exists;
+use const PHP_EOL;
+
+/**
+ * 队列命令
+ *
+ * 用于管理 Redis 队列系统
+ */
+final class Queue extends Command
+{
+    public string $description = <<<EOL
+├─=: php xcat Queue [选项]
+│ ├─ work [options]      - 启动队列 Worker
+│ │   --queue=default    - 指定监听的队列（可用逗号分隔多个）
+│ │   --max-jobs=0       - 最大处理任务数（0=无限制）
+│ │   --max-time=0       - 最大运行时间秒数（0=无限制）
+│ │   --memory=128       - 内存限制 MB
+│ │   --sleep=1000000    - 空闲休眠微秒
+│ ├─ status              - 查看队列状态
+│ ├─ failed              - 查看失败任务列表
+│ ├─ retry [job_id]      - 重试失败任务（不指定ID则重试全部）
+│ ├─ flush               - 清空死信队列
+│ ├─ recover             - 恢复卡住的任务
+│ └─ migrate             - 迁移数据库邮件队列到Redis
+
+EOL;
+
+    public function boot(): void
+    {
+        if (count($this->argv) < 3) {
+            echo $this->description;
+            return;
+        }
+
+        $action = $this->argv[2];
+
+        match ($action) {
+            'work' => $this->work(),
+            'status' => $this->status(),
+            'failed' => $this->failed(),
+            'retry' => $this->retry(),
+            'flush' => $this->flush(),
+            'recover' => $this->recover(),
+            'migrate' => $this->migrate(),
+            default => $this->unknownCommand($action),
+        };
+    }
+
+    /**
+     * 启动 Worker
+     */
+    private function work(): void
+    {
+        $options = $this->parseOptions(array_slice($this->argv, 3));
+
+        // 解析队列参数
+        $queuesString = $options['queue'] ?? 'default';
+        $queues = array_map('trim', explode(',', $queuesString));
+
+        // 验证队列名称
+        $validQueues = [
+            RedisQueue::QUEUE_DEFAULT,
+            RedisQueue::QUEUE_EMAIL,
+            RedisQueue::QUEUE_NOTIFICATION,
+            RedisQueue::QUEUE_HIGH,
+        ];
+
+        foreach ($queues as $queue) {
+            if (!in_array($queue, $validQueues, true)) {
+                echo "警告: 队列 '{$queue}' 不是预定义队列，但仍会监听" . PHP_EOL;
+            }
+        }
+
+        $maxJobs = (int)($options['max-jobs'] ?? 0);
+        $maxTime = (int)($options['max-time'] ?? 0);
+        $memory = (int)($options['memory'] ?? 128);
+        $sleep = (int)($options['sleep'] ?? 1000000);
+
+        echo "启动参数:" . PHP_EOL;
+        echo "  队列: " . implode(', ', $queues) . PHP_EOL;
+        echo "  最大任务数: " . ($maxJobs > 0 ? $maxJobs : '无限制') . PHP_EOL;
+        echo "  最大运行时间: " . ($maxTime > 0 ? $maxTime . 's' : '无限制') . PHP_EOL;
+        echo "  内存限制: {$memory}MB" . PHP_EOL;
+        echo "  休眠间隔: {$sleep}μs" . PHP_EOL;
+        echo PHP_EOL;
+
+        $worker = new Worker($queues, $maxJobs, $maxTime, $memory, $sleep);
+        $worker->run();
+    }
+
+    /**
+     * 查看队列状态
+     */
+    private function status(): void
+    {
+        $queue = new RedisQueue();
+        $stats = $queue->stats();
+
+        echo PHP_EOL;
+        echo "╔═══════════════════════════════════════════════════════════╗" . PHP_EOL;
+        echo "║                      队列状态                              ║" . PHP_EOL;
+        echo "╠═══════════════════════════════════════════════════════════╣" . PHP_EOL;
+
+        foreach ($stats['queues'] as $name => $data) {
+            $total = $data['pending'] + $data['delayed'] + $data['processing'];
+            echo sprintf(
+                "║ %-12s │ 待处理: %-5d │ 延迟: %-5d │ 处理中: %-5d ║" . PHP_EOL,
+                $name,
+                $data['pending'],
+                $data['delayed'],
+                $data['processing']
+            );
+        }
+
+        echo "╠═══════════════════════════════════════════════════════════╣" . PHP_EOL;
+        echo sprintf("║ 死信队列: %-47d ║" . PHP_EOL, $stats['failed']);
+        echo "╚═══════════════════════════════════════════════════════════╝" . PHP_EOL;
+        echo PHP_EOL;
+    }
+
+    /**
+     * 查看失败任务
+     */
+    private function failed(): void
+    {
+        $queue = new RedisQueue();
+        $jobs = $queue->getFailedJobs(50);
+
+        if (empty($jobs)) {
+            echo "死信队列为空" . PHP_EOL;
+            return;
+        }
+
+        echo PHP_EOL;
+        echo "失败任务列表:" . PHP_EOL;
+        echo str_repeat('-', 100) . PHP_EOL;
+
+        foreach ($jobs as $index => $job) {
+            echo sprintf(
+                "%d. [%s] %s" . PHP_EOL,
+                $index + 1,
+                $job['id'] ?? 'unknown',
+                $job['class'] ?? 'unknown'
+            );
+            echo "   队列: " . ($job['queue'] ?? 'unknown') . PHP_EOL;
+            echo "   尝试次数: " . ($job['attempts'] ?? 0) . PHP_EOL;
+            echo "   错误信息: " . ($job['last_error'] ?? 'unknown') . PHP_EOL;
+            echo "   失败时间: " . (isset($job['failed_at']) ? Tools::toDateTime($job['failed_at']) : 'unknown') . PHP_EOL;
+            echo str_repeat('-', 100) . PHP_EOL;
+        }
+
+        echo PHP_EOL;
+    }
+
+    /**
+     * 重试失败任务
+     */
+    private function retry(): void
+    {
+        $jobId = $this->argv[3] ?? null;
+        $queue = new RedisQueue();
+
+        if ($jobId !== null) {
+            $count = $queue->retryFailed($jobId);
+            if ($count > 0) {
+                echo "任务 {$jobId} 已重新加入队列" . PHP_EOL;
+            } else {
+                echo "未找到任务 {$jobId}" . PHP_EOL;
+            }
+        } else {
+            $count = $queue->retryFailed();
+            echo "已将 {$count} 个失败任务重新加入队列" . PHP_EOL;
+        }
+    }
+
+    /**
+     * 清空死信队列
+     */
+    private function flush(): void
+    {
+        $queue = new RedisQueue();
+        $count = $queue->flushFailed();
+        echo "已清空死信队列，删除 {$count} 个任务" . PHP_EOL;
+    }
+
+    /**
+     * 恢复卡住的任务
+     */
+    private function recover(): void
+    {
+        $queue = new RedisQueue();
+        $count = $queue->recoverStuckJobs(3600);
+        echo "已恢复 {$count} 个卡住的任务" . PHP_EOL;
+    }
+
+    /**
+     * 迁移数据库邮件队列到 Redis
+     */
+    private function migrate(): void
+    {
+        echo "正在迁移数据库邮件队列到 Redis..." . PHP_EOL;
+
+        // 使用数据库操作
+        $emails = DB::select('SELECT * FROM email_queue');
+
+        if (empty($emails)) {
+            echo "数据库邮件队列为空，无需迁移" . PHP_EOL;
+            return;
+        }
+
+        $queue = new RedisQueue();
+        $count = 0;
+
+        foreach ($emails as $email) {
+            $queue->push(
+                SendEmailJob::class,
+                [
+                    'to_email' => $email->to_email,
+                    'subject' => $email->subject,
+                    'template' => $email->template,
+                    'array' => json_decode($email->array, true) ?? [],
+                ],
+                RedisQueue::QUEUE_EMAIL
+            );
+            $count++;
+        }
+
+        echo "已迁移 {$count} 封邮件到 Redis 队列" . PHP_EOL;
+        echo "如需删除数据库中的邮件队列记录，请手动执行: DELETE FROM email_queue" . PHP_EOL;
+    }
+
+    /**
+     * 未知命令处理
+     */
+    private function unknownCommand(string $action): void
+    {
+        echo "未知命令: {$action}" . PHP_EOL . $this->description;
+    }
+
+    /**
+     * 解析命令行选项
+     */
+    private function parseOptions(array $args): array
+    {
+        $options = [];
+
+        foreach ($args as $arg) {
+            if (str_starts_with($arg, '--')) {
+                $parts = explode('=', substr($arg, 2), 2);
+                $key = $parts[0];
+                $value = $parts[1] ?? true;
+                $options[$key] = $value;
+            }
+        }
+
+        return $options;
+    }
+}

--- a/src/Controllers/Admin/AnnController.php
+++ b/src/Controllers/Admin/AnnController.php
@@ -7,7 +7,7 @@ namespace App\Controllers\Admin;
 use App\Controllers\BaseController;
 use App\Models\Ann;
 use App\Models\Config;
-use App\Models\EmailQueue;
+use App\Services\Queue\Queue;
 use App\Models\User;
 use App\Services\Notification;
 use App\Utils\Tools;
@@ -109,7 +109,7 @@ final class AnnController extends BaseController
             $subject = $_ENV['appName'] . ' - 新公告发布';
 
             foreach ($users as $user) {
-                (new EmailQueue())->add(
+                Queue::email(
                     $user->email,
                     $subject,
                     'warn.tpl',

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -6,6 +6,7 @@ namespace App\Models;
 
 use App\Services\IM;
 use App\Services\IM\Telegram;
+use App\Services\Queue\Queue;
 use App\Utils\Tools;
 use GuzzleHttp\Exception\GuzzleException;
 use Illuminate\Database\Query\Builder;
@@ -289,7 +290,7 @@ final class User extends Model
         if ($this->daily_mail_enable === 1) {
             echo 'Sending daily mail to user: ' . $this->id . PHP_EOL;
 
-            (new EmailQueue())->add(
+            Queue::email(
                 $this->email,
                 $_ENV['appName'] . '-每日流量报告以及公告',
                 'traffic_report.tpl',
@@ -313,7 +314,7 @@ final class User extends Model
 
             try {
                 IM::send((int) $this->im_value, $text, $this->im_type);
-            } catch (GuzzleException|TelegramSDKException $e) {
+            } catch (GuzzleException | TelegramSDKException $e) {
                 echo $e->getMessage() . PHP_EOL;
             }
         }

--- a/src/Services/Notification.php
+++ b/src/Services/Notification.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace App\Services;
 
 use App\Models\Config;
-use App\Models\EmailQueue;
 use App\Models\User;
+use App\Services\Queue\Queue;
 use GuzzleHttp\Exception\GuzzleException;
 use Psr\Http\Client\ClientExceptionInterface;
 use Telegram\Bot\Exceptions\TelegramSDKException;
@@ -24,7 +24,7 @@ final class Notification
 
         foreach ($admins as $admin) {
             if ($admin->contact_method === 1 || $admin->im_type === 0) {
-                (new EmailQueue())->add(
+                Queue::email(
                     $admin->email,
                     $title,
                     $template,
@@ -48,7 +48,7 @@ final class Notification
     public static function notifyUser($user, $title = '', $msg = '', $template = 'warn.tpl'): void
     {
         if ($user->contact_method === 1 || $user->im_type === 0) {
-            (new EmailQueue())->add(
+            Queue::email(
                 $user->email,
                 $title,
                 $template,
@@ -73,7 +73,7 @@ final class Notification
 
         foreach ($users as $user) {
             if ($user->contact_method === 1 || $user->im_type === 0) {
-                (new EmailQueue())->add(
+                Queue::email(
                     $user->email,
                     $title,
                     $template,

--- a/src/Services/Password.php
+++ b/src/Services/Password.php
@@ -5,14 +5,13 @@ declare(strict_types=1);
 namespace App\Services;
 
 use App\Models\Config;
+use App\Services\Queue\Queue;
 use App\Utils\Tools;
-use Psr\Http\Client\ClientExceptionInterface;
 use RedisException;
 
 final class Password
 {
     /**
-     * @throws ClientExceptionInterface
      * @throws RedisException
      */
     public static function sendResetEmail($email): void
@@ -25,7 +24,7 @@ final class Password
         $subject = $_ENV['appName'] . '-重置密码';
         $resetUrl = $_ENV['baseUrl'] . '/password/token/' . $token;
 
-        Mail::send(
+        Queue::email(
             $email,
             $subject,
             'password_reset.tpl',

--- a/src/Services/Queue/JobInterface.php
+++ b/src/Services/Queue/JobInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Queue;
+
+/**
+ * 队列任务接口
+ *
+ * 所有队列任务都必须实现此接口
+ */
+interface JobInterface
+{
+    /**
+     * 执行任务
+     *
+     * @param array $payload 任务数据
+     * @return void
+     * @throws \Exception 任务执行失败时抛出异常
+     */
+    public function handle(array $payload): void;
+
+    /**
+     * 获取任务所属队列
+     *
+     * @return string
+     */
+    public static function getQueue(): string;
+
+    /**
+     * 任务失败时的回调
+     *
+     * @param array $payload 任务数据
+     * @param \Throwable $exception 异常
+     * @return void
+     */
+    public function failed(array $payload, \Throwable $exception): void;
+}

--- a/src/Services/Queue/Jobs/SendEmailJob.php
+++ b/src/Services/Queue/Jobs/SendEmailJob.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Queue\Jobs;
+
+use App\Services\Mail;
+use App\Services\Queue\JobInterface;
+use App\Services\Queue\RedisQueue;
+use App\Utils\Tools;
+use Throwable;
+use function json_encode;
+
+/**
+ * 邮件发送任务
+ */
+final class SendEmailJob implements JobInterface
+{
+    /**
+     * 执行邮件发送
+     *
+     * @param array $payload 包含 to_email, subject, template, array
+     */
+    public function handle(array $payload): void
+    {
+        $toEmail = $payload['to_email'];
+        $subject = $payload['subject'];
+        $template = $payload['template'];
+        $templateData = $payload['array'] ?? [];
+
+        // 验证邮箱格式
+        if (!Tools::isEmail($toEmail)) {
+            throw new \InvalidArgumentException("Invalid email address: {$toEmail}");
+        }
+
+        Mail::send($toEmail, $subject, $template, $templateData);
+    }
+
+    /**
+     * 获取任务所属队列
+     */
+    public static function getQueue(): string
+    {
+        return RedisQueue::QUEUE_EMAIL;
+    }
+
+    /**
+     * 任务失败时的回调
+     */
+    public function failed(array $payload, Throwable $exception): void
+    {
+        // 记录失败日志
+        error_log(sprintf(
+            '[SendEmailJob] Failed to send email to %s: %s | Payload: %s',
+            $payload['to_email'] ?? 'unknown',
+            $exception->getMessage(),
+            json_encode($payload, JSON_UNESCAPED_UNICODE)
+        ));
+    }
+
+    /**
+     * 快捷方法：将邮件任务加入队列
+     */
+    public static function dispatch(
+        string $toEmail,
+        string $subject,
+        string $template,
+        array $templateData = [],
+        int $delay = 0
+    ): string {
+        $queue = new RedisQueue();
+
+        return $queue->push(
+            self::class,
+            [
+                'to_email' => $toEmail,
+                'subject' => $subject,
+                'template' => $template,
+                'array' => $templateData,
+            ],
+            self::getQueue(),
+            $delay
+        );
+    }
+
+    /**
+     * 批量发送邮件
+     */
+    public static function dispatchBatch(array $emails): array
+    {
+        $queue = new RedisQueue();
+        $jobs = [];
+
+        foreach ($emails as $email) {
+            $jobs[] = [
+                'class' => self::class,
+                'payload' => [
+                    'to_email' => $email['to_email'],
+                    'subject' => $email['subject'],
+                    'template' => $email['template'],
+                    'array' => $email['array'] ?? [],
+                ],
+                'delay' => $email['delay'] ?? 0,
+            ];
+        }
+
+        return $queue->pushBatch($jobs, self::getQueue());
+    }
+}

--- a/src/Services/Queue/Jobs/SendNotificationJob.php
+++ b/src/Services/Queue/Jobs/SendNotificationJob.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Queue\Jobs;
+
+use App\Services\IM;
+use App\Services\Queue\JobInterface;
+use App\Services\Queue\RedisQueue;
+use Throwable;
+use function json_encode;
+
+/**
+ * IM 通知任务
+ */
+final class SendNotificationJob implements JobInterface
+{
+    /**
+     * 执行通知发送
+     *
+     * @param array $payload 包含 im_value, message, im_type
+     */
+    public function handle(array $payload): void
+    {
+        $imValue = $payload['im_value'];
+        $message = $payload['message'];
+        $imType = $payload['im_type'] ?? 0;
+
+        IM::send($imValue, $message, $imType);
+    }
+
+    /**
+     * 获取任务所属队列
+     */
+    public static function getQueue(): string
+    {
+        return RedisQueue::QUEUE_NOTIFICATION;
+    }
+
+    /**
+     * 任务失败时的回调
+     */
+    public function failed(array $payload, Throwable $exception): void
+    {
+        error_log(sprintf(
+            '[SendNotificationJob] Failed to send notification: %s | Payload: %s',
+            $exception->getMessage(),
+            json_encode($payload, JSON_UNESCAPED_UNICODE)
+        ));
+    }
+
+    /**
+     * 快捷方法：将通知任务加入队列
+     */
+    public static function dispatch(
+        mixed $imValue,
+        string $message,
+        int $imType = 0,
+        int $delay = 0
+    ): string {
+        $queue = new RedisQueue();
+
+        return $queue->push(
+            self::class,
+            [
+                'im_value' => $imValue,
+                'message' => $message,
+                'im_type' => $imType,
+            ],
+            self::getQueue(),
+            $delay
+        );
+    }
+}

--- a/src/Services/Queue/Queue.php
+++ b/src/Services/Queue/Queue.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Queue;
+
+use App\Models\EmailQueue;
+use App\Services\Queue\Jobs\SendEmailJob;
+use App\Services\Queue\Jobs\SendNotificationJob;
+
+/**
+ * 队列门面类
+ *
+ * 提供统一的队列操作接口，自动根据配置选择使用 Redis 或数据库队列
+ */
+final class Queue
+{
+    /**
+     * 判断是否使用 Redis 队列
+     */
+    public static function useRedis(): bool
+    {
+        return (bool) ($_ENV['enable_redis_queue'] ?? false);
+    }
+
+    /**
+     * 发送邮件（自动选择队列）
+     */
+    public static function email(
+        string $toEmail,
+        string $subject,
+        string $template,
+        array $templateData = [],
+        int $delay = 0
+    ): void {
+        if (self::useRedis()) {
+            SendEmailJob::dispatch($toEmail, $subject, $template, $templateData, $delay);
+        } else {
+            // 使用数据库队列（不支持延迟）
+            (new EmailQueue())->add($toEmail, $subject, $template, $templateData);
+        }
+    }
+
+    /**
+     * 批量发送邮件
+     */
+    public static function emailBatch(array $emails): void
+    {
+        if (self::useRedis()) {
+            SendEmailJob::dispatchBatch($emails);
+        } else {
+            foreach ($emails as $email) {
+                (new EmailQueue())->add(
+                    $email['to_email'],
+                    $email['subject'],
+                    $email['template'],
+                    $email['array'] ?? []
+                );
+            }
+        }
+    }
+
+    /**
+     * 发送通知（仅 Redis 队列支持）
+     */
+    public static function notification(
+        mixed $imValue,
+        string $message,
+        int $imType = 0,
+        int $delay = 0
+    ): void {
+        if (self::useRedis()) {
+            SendNotificationJob::dispatch($imValue, $message, $imType, $delay);
+        } else {
+            // 数据库队列不支持通知，直接发送
+            \App\Services\IM::send($imValue, $message, $imType);
+        }
+    }
+
+    /**
+     * 推送自定义任务到队列
+     *
+     * @param string $jobClass 任务类名（必须实现 JobInterface）
+     * @param array $payload 任务数据
+     * @param string $queue 队列名称
+     * @param int $delay 延迟秒数
+     */
+    public static function push(
+        string $jobClass,
+        array $payload = [],
+        string $queue = RedisQueue::QUEUE_DEFAULT,
+        int $delay = 0
+    ): ?string {
+        if (!self::useRedis()) {
+            throw new \RuntimeException('Custom jobs require Redis queue to be enabled');
+        }
+
+        $redisQueue = new RedisQueue();
+        return $redisQueue->push($jobClass, $payload, $queue, $delay);
+    }
+
+    /**
+     * 获取队列状态
+     */
+    public static function stats(): array
+    {
+        if (self::useRedis()) {
+            $redisQueue = new RedisQueue();
+            return $redisQueue->stats();
+        }
+
+        // 数据库队列统计
+        return [
+            'queues' => [
+                'email' => [
+                    'pending' => (new EmailQueue())->count(),
+                    'delayed' => 0,
+                    'processing' => 0,
+                ],
+            ],
+            'failed' => 0,
+        ];
+    }
+}

--- a/src/Services/Queue/RedisQueue.php
+++ b/src/Services/Queue/RedisQueue.php
@@ -1,0 +1,387 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Queue;
+
+use App\Services\Cache;
+use Redis;
+use Throwable;
+use function json_decode;
+use function json_encode;
+use function time;
+
+/**
+ * Redis 队列服务
+ *
+ * 支持功能：
+ * - 多队列支持
+ * - 延迟任务
+ * - 失败重试
+ * - 死信队列
+ * - 任务优先级
+ */
+final class RedisQueue
+{
+    private Redis $redis;
+    private string $prefix = 'sspanel:queue:';
+
+    // 队列名称常量
+    public const QUEUE_DEFAULT = 'default';
+    public const QUEUE_EMAIL = 'email';
+    public const QUEUE_NOTIFICATION = 'notification';
+    public const QUEUE_HIGH = 'high';
+
+    // 最大重试次数
+    private int $maxRetries = 3;
+
+    // 重试延迟（秒），指数退避
+    private array $retryDelays = [60, 300, 900]; // 1分钟, 5分钟, 15分钟
+
+    public function __construct()
+    {
+        $this->redis = (new Cache())->initRedis();
+    }
+
+    /**
+     * 获取队列键名
+     */
+    private function getQueueKey(string $queue): string
+    {
+        return $this->prefix . $queue;
+    }
+
+    /**
+     * 获取延迟队列键名
+     */
+    private function getDelayedKey(string $queue): string
+    {
+        return $this->prefix . 'delayed:' . $queue;
+    }
+
+    /**
+     * 获取死信队列键名
+     */
+    private function getFailedKey(): string
+    {
+        return $this->prefix . 'failed';
+    }
+
+    /**
+     * 获取处理中队列键名
+     */
+    private function getProcessingKey(string $queue): string
+    {
+        return $this->prefix . 'processing:' . $queue;
+    }
+
+    /**
+     * 推送任务到队列
+     *
+     * @param string $jobClass 任务类名
+     * @param array $payload 任务数据
+     * @param string $queue 队列名称
+     * @param int $delay 延迟秒数，0表示立即执行
+     */
+    public function push(string $jobClass, array $payload = [], string $queue = self::QUEUE_DEFAULT, int $delay = 0): string
+    {
+        $jobId = $this->generateJobId();
+
+        $job = [
+            'id' => $jobId,
+            'class' => $jobClass,
+            'payload' => $payload,
+            'queue' => $queue,
+            'attempts' => 0,
+            'max_retries' => $this->maxRetries,
+            'created_at' => time(),
+            'available_at' => time() + $delay,
+        ];
+
+        $serialized = json_encode($job, JSON_UNESCAPED_UNICODE);
+
+        if ($delay > 0) {
+            // 延迟任务使用有序集合
+            $this->redis->zAdd(
+                $this->getDelayedKey($queue),
+                time() + $delay,
+                $serialized
+            );
+        } else {
+            // 立即执行的任务使用列表
+            $this->redis->rPush($this->getQueueKey($queue), $serialized);
+        }
+
+        return $jobId;
+    }
+
+    /**
+     * 批量推送任务
+     */
+    public function pushBatch(array $jobs, string $queue = self::QUEUE_DEFAULT): array
+    {
+        $jobIds = [];
+
+        foreach ($jobs as $job) {
+            $jobIds[] = $this->push(
+                $job['class'],
+                $job['payload'] ?? [],
+                $queue,
+                $job['delay'] ?? 0
+            );
+        }
+
+        return $jobIds;
+    }
+
+    /**
+     * 从队列中取出一个任务
+     *
+     * @param string $queue 队列名称
+     * @param int $timeout 阻塞等待超时（秒）
+     * @return array|null
+     */
+    public function pop(string $queue = self::QUEUE_DEFAULT, int $timeout = 5): ?array
+    {
+        // 先处理延迟队列中到期的任务
+        $this->migrateDelayedJobs($queue);
+
+        // 使用 BLMOVE 原子操作（Redis 6.2+），如果不支持则降级使用 BRPOPLPUSH
+        $result = $this->redis->brPoplPush(
+            $this->getQueueKey($queue),
+            $this->getProcessingKey($queue),
+            $timeout
+        );
+
+        if ($result === false) {
+            return null;
+        }
+
+        return json_decode($result, true);
+    }
+
+    /**
+     * 将延迟队列中到期的任务移动到主队列
+     */
+    private function migrateDelayedJobs(string $queue): void
+    {
+        $now = time();
+        $delayedKey = $this->getDelayedKey($queue);
+        $queueKey = $this->getQueueKey($queue);
+
+        // 获取所有到期的延迟任务
+        $jobs = $this->redis->zRangeByScore($delayedKey, '-inf', (string) $now);
+
+        foreach ($jobs as $job) {
+            // 原子操作：从延迟队列移除并添加到主队列
+            $removed = $this->redis->zRem($delayedKey, $job);
+            if ($removed > 0) {
+                $this->redis->rPush($queueKey, $job);
+            }
+        }
+    }
+
+    /**
+     * 确认任务完成
+     */
+    public function acknowledge(array $job): void
+    {
+        $serialized = json_encode($job, JSON_UNESCAPED_UNICODE);
+        $this->redis->lRem($this->getProcessingKey($job['queue']), $serialized, 1);
+    }
+
+    /**
+     * 任务失败处理
+     *
+     * @param array $job 任务数据
+     * @param Throwable $exception 异常
+     * @return bool 是否重新入队
+     */
+    public function fail(array $job, Throwable $exception): bool
+    {
+        $serialized = json_encode($job, JSON_UNESCAPED_UNICODE);
+        $this->redis->lRem($this->getProcessingKey($job['queue']), $serialized, 1);
+
+        $job['attempts']++;
+        $job['last_error'] = $exception->getMessage();
+        $job['failed_at'] = time();
+
+        // 检查是否还能重试
+        if ($job['attempts'] < $job['max_retries']) {
+            // 计算重试延迟
+            $delayIndex = min($job['attempts'] - 1, count($this->retryDelays) - 1);
+            $delay = $this->retryDelays[$delayIndex];
+
+            // 重新加入延迟队列
+            $job['available_at'] = time() + $delay;
+            $this->redis->zAdd(
+                $this->getDelayedKey($job['queue']),
+                $job['available_at'],
+                json_encode($job, JSON_UNESCAPED_UNICODE)
+            );
+
+            return true;
+        }
+
+        // 超过重试次数，移入死信队列
+        $this->redis->rPush($this->getFailedKey(), json_encode($job, JSON_UNESCAPED_UNICODE));
+
+        return false;
+    }
+
+    /**
+     * 重试死信队列中的任务
+     */
+    public function retryFailed(?string $jobId = null): int
+    {
+        $count = 0;
+        $failedKey = $this->getFailedKey();
+
+        if ($jobId !== null) {
+            // 重试指定任务
+            $length = $this->redis->lLen($failedKey);
+            for ($i = 0; $i < $length; $i++) {
+                $job = json_decode($this->redis->lIndex($failedKey, $i), true);
+                if ($job && $job['id'] === $jobId) {
+                    $this->redis->lRem($failedKey, json_encode($job, JSON_UNESCAPED_UNICODE), 1);
+                    $job['attempts'] = 0;
+                    $job['available_at'] = time();
+                    unset($job['last_error'], $job['failed_at']);
+                    $this->redis->rPush($this->getQueueKey($job['queue']), json_encode($job, JSON_UNESCAPED_UNICODE));
+                    $count++;
+                    break;
+                }
+            }
+        } else {
+            // 重试所有失败任务
+            while ($serialized = $this->redis->lPop($failedKey)) {
+                $job = json_decode($serialized, true);
+                $job['attempts'] = 0;
+                $job['available_at'] = time();
+                unset($job['last_error'], $job['failed_at']);
+                $this->redis->rPush($this->getQueueKey($job['queue']), json_encode($job, JSON_UNESCAPED_UNICODE));
+                $count++;
+            }
+        }
+
+        return $count;
+    }
+
+    /**
+     * 清空死信队列
+     */
+    public function flushFailed(): int
+    {
+        $count = $this->redis->lLen($this->getFailedKey());
+        $this->redis->del($this->getFailedKey());
+        return $count;
+    }
+
+    /**
+     * 获取队列统计信息
+     */
+    public function stats(?string $queue = null): array
+    {
+        $queues = $queue !== null ? [$queue] : [
+            self::QUEUE_DEFAULT,
+            self::QUEUE_EMAIL,
+            self::QUEUE_NOTIFICATION,
+            self::QUEUE_HIGH,
+        ];
+
+        $stats = [
+            'queues' => [],
+            'failed' => $this->redis->lLen($this->getFailedKey()),
+        ];
+
+        foreach ($queues as $q) {
+            $stats['queues'][$q] = [
+                'pending' => $this->redis->lLen($this->getQueueKey($q)),
+                'delayed' => $this->redis->zCard($this->getDelayedKey($q)),
+                'processing' => $this->redis->lLen($this->getProcessingKey($q)),
+            ];
+        }
+
+        return $stats;
+    }
+
+    /**
+     * 获取失败任务列表
+     */
+    public function getFailedJobs(int $limit = 50, int $offset = 0): array
+    {
+        $jobs = $this->redis->lRange($this->getFailedKey(), $offset, $offset + $limit - 1);
+
+        return array_map(static fn($job) => json_decode($job, true), $jobs);
+    }
+
+    /**
+     * 删除指定失败任务
+     */
+    public function deleteFailed(string $jobId): bool
+    {
+        $failedKey = $this->getFailedKey();
+        $length = $this->redis->lLen($failedKey);
+
+        for ($i = 0; $i < $length; $i++) {
+            $job = json_decode($this->redis->lIndex($failedKey, $i), true);
+            if ($job && $job['id'] === $jobId) {
+                $this->redis->lRem($failedKey, json_encode($job, JSON_UNESCAPED_UNICODE), 1);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * 生成唯一任务ID
+     */
+    private function generateJobId(): string
+    {
+        return uniqid('job_', true) . '_' . bin2hex(random_bytes(4));
+    }
+
+    /**
+     * 清理超时的处理中任务（用于异常恢复）
+     *
+     * @param int $timeout 超时时间（秒）
+     */
+    public function recoverStuckJobs(int $timeout = 3600): int
+    {
+        $count = 0;
+        $queues = [
+            self::QUEUE_DEFAULT,
+            self::QUEUE_EMAIL,
+            self::QUEUE_NOTIFICATION,
+            self::QUEUE_HIGH,
+        ];
+
+        foreach ($queues as $queue) {
+            $processingKey = $this->getProcessingKey($queue);
+            $jobs = $this->redis->lRange($processingKey, 0, -1);
+
+            foreach ($jobs as $serialized) {
+                $job = json_decode($serialized, true);
+                // 检查任务是否超时
+                if (isset($job['available_at']) && time() - $job['available_at'] > $timeout) {
+                    $this->redis->lRem($processingKey, $serialized, 1);
+                    // 重新加入队列
+                    $job['available_at'] = time();
+                    $this->redis->rPush($this->getQueueKey($queue), json_encode($job, JSON_UNESCAPED_UNICODE));
+                    $count++;
+                }
+            }
+        }
+
+        return $count;
+    }
+
+    /**
+     * 关闭 Redis 连接
+     */
+    public function close(): void
+    {
+        $this->redis->close();
+    }
+}

--- a/src/Services/Queue/Worker.php
+++ b/src/Services/Queue/Worker.php
@@ -1,0 +1,233 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Queue;
+
+use App\Utils\Tools;
+use Exception;
+use Throwable;
+use function class_exists;
+use function class_implements;
+use function in_array;
+use function pcntl_async_signals;
+use function pcntl_signal;
+use function time;
+use const PHP_EOL;
+use const SIGINT;
+use const SIGTERM;
+
+/**
+ * 队列 Worker
+ *
+ * 负责从队列中取出任务并执行
+ */
+final class Worker
+{
+    private RedisQueue $queue;
+    private bool $shouldQuit = false;
+    private int $processedJobs = 0;
+    private int $failedJobs = 0;
+
+    /**
+     * @var string[] 要监听的队列列表
+     */
+    private array $queues;
+
+    /**
+     * @var int 每批次最大处理任务数，0表示无限制
+     */
+    private int $maxJobs;
+
+    /**
+     * @var int 最大运行时间（秒），0表示无限制
+     */
+    private int $maxTime;
+
+    /**
+     * @var int 内存限制（MB），0表示无限制
+     */
+    private int $memoryLimit;
+
+    /**
+     * @var int 任务间休眠时间（微秒）
+     */
+    private int $sleep;
+
+    private int $startTime;
+
+    public function __construct(
+        array $queues = [RedisQueue::QUEUE_DEFAULT],
+        int $maxJobs = 0,
+        int $maxTime = 0,
+        int $memoryLimit = 128,
+        int $sleep = 1000000
+    ) {
+        $this->queue = new RedisQueue();
+        $this->queues = $queues;
+        $this->maxJobs = $maxJobs;
+        $this->maxTime = $maxTime;
+        $this->memoryLimit = $memoryLimit;
+        $this->sleep = $sleep;
+        $this->startTime = time();
+
+        $this->registerSignalHandlers();
+    }
+
+    /**
+     * 注册信号处理器（优雅关闭）
+     */
+    private function registerSignalHandlers(): void
+    {
+        if (extension_loaded('pcntl')) {
+            pcntl_async_signals(true);
+            pcntl_signal(SIGTERM, fn() => $this->shouldQuit = true);
+            pcntl_signal(SIGINT, fn() => $this->shouldQuit = true);
+        }
+    }
+
+    /**
+     * 启动 Worker
+     */
+    public function run(): void
+    {
+        echo Tools::toDateTime(time()) . " Worker 启动，监听队列: " . implode(', ', $this->queues) . PHP_EOL;
+
+        while (!$this->shouldQuit) {
+            // 检查是否达到限制条件
+            if ($this->shouldStop()) {
+                break;
+            }
+
+            // 轮询所有队列
+            $jobProcessed = false;
+            foreach ($this->queues as $queueName) {
+                $job = $this->queue->pop($queueName, 1);
+
+                if ($job !== null) {
+                    $this->processJob($job);
+                    $jobProcessed = true;
+                    break; // 处理完一个任务后重新开始轮询
+                }
+            }
+
+            // 如果没有任务，休眠一段时间
+            if (!$jobProcessed) {
+                usleep($this->sleep);
+            }
+        }
+
+        $this->shutdown();
+    }
+
+    /**
+     * 处理单个任务
+     */
+    private function processJob(array $job): void
+    {
+        $jobId = $job['id'] ?? 'unknown';
+        $jobClass = $job['class'] ?? '';
+        $payload = $job['payload'] ?? [];
+        $attempts = $job['attempts'] ?? 0;
+
+        echo Tools::toDateTime(time()) . " [处理中] Job: {$jobId} | Class: {$jobClass} | 尝试次数: " . ($attempts + 1) . PHP_EOL;
+
+        try {
+            // 验证任务类
+            if (!class_exists($jobClass)) {
+                throw new Exception("Job class not found: {$jobClass}");
+            }
+
+            $implements = class_implements($jobClass);
+            if (!in_array(JobInterface::class, $implements, true)) {
+                throw new Exception("Job class must implement JobInterface: {$jobClass}");
+            }
+
+            // 实例化并执行任务
+            $handler = new $jobClass();
+            $handler->handle($payload);
+
+            // 任务完成，确认
+            $this->queue->acknowledge($job);
+            $this->processedJobs++;
+
+            echo Tools::toDateTime(time()) . " [完成] Job: {$jobId}" . PHP_EOL;
+        } catch (Throwable $e) {
+            echo Tools::toDateTime(time()) . " [失败] Job: {$jobId} | Error: " . $e->getMessage() . PHP_EOL;
+
+            // 调用任务的失败回调
+            if (isset($handler) && $handler instanceof JobInterface) {
+                try {
+                    $handler->failed($payload, $e);
+                } catch (Throwable $callbackException) {
+                    echo Tools::toDateTime(time()) . " [警告] Failed callback error: " . $callbackException->getMessage() . PHP_EOL;
+                }
+            }
+
+            // 处理失败（重试或移入死信队列）
+            $willRetry = $this->queue->fail($job, $e);
+            $this->failedJobs++;
+
+            if ($willRetry) {
+                echo Tools::toDateTime(time()) . " [重试] Job: {$jobId} 将在稍后重试" . PHP_EOL;
+            } else {
+                echo Tools::toDateTime(time()) . " [死信] Job: {$jobId} 已移入死信队列" . PHP_EOL;
+            }
+        }
+    }
+
+    /**
+     * 检查是否应该停止
+     */
+    private function shouldStop(): bool
+    {
+        // 检查最大任务数
+        if ($this->maxJobs > 0 && $this->processedJobs >= $this->maxJobs) {
+            echo Tools::toDateTime(time()) . " 已达到最大任务数限制 ({$this->maxJobs})" . PHP_EOL;
+            return true;
+        }
+
+        // 检查最大运行时间
+        if ($this->maxTime > 0 && (time() - $this->startTime) >= $this->maxTime) {
+            echo Tools::toDateTime(time()) . " 已达到最大运行时间限制 ({$this->maxTime}s)" . PHP_EOL;
+            return true;
+        }
+
+        // 检查内存限制
+        $memoryUsage = memory_get_usage(true) / 1024 / 1024;
+        if ($this->memoryLimit > 0 && $memoryUsage >= $this->memoryLimit) {
+            echo Tools::toDateTime(time()) . " 已达到内存限制 ({$this->memoryLimit}MB)" . PHP_EOL;
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * 关闭 Worker
+     */
+    private function shutdown(): void
+    {
+        $runtime = time() - $this->startTime;
+        $memoryPeak = round(memory_get_peak_usage(true) / 1024 / 1024, 2);
+
+        echo PHP_EOL;
+        echo Tools::toDateTime(time()) . " Worker 关闭" . PHP_EOL;
+        echo "运行时间: {$runtime}s | 处理任务: {$this->processedJobs} | 失败任务: {$this->failedJobs} | 峰值内存: {$memoryPeak}MB" . PHP_EOL;
+
+        $this->queue->close();
+    }
+
+    /**
+     * 获取统计信息
+     */
+    public function getStats(): array
+    {
+        return [
+            'processed' => $this->processedJobs,
+            'failed' => $this->failedJobs,
+            'runtime' => time() - $this->startTime,
+            'memory_peak' => memory_get_peak_usage(true),
+        ];
+    }
+}


### PR DESCRIPTION
## 变更说明

对队列系统进行了重构，实现了如下主要改动：

- **所有邮件发送统一提交到队列**  
  所有业务场景（如注册、找回密码、公告、通知、流量报告等）均通过队列异步发送邮件。
- **支持 Redis 队列与数据库队列自动切换**  
  通过 `.config.php` 配置项 `enable_redis_queue`，可切换队列实现。开启后所有邮件任务将进入 Redis 队列，由 Worker 进程异步处理；关闭时回退为原有数据库队列表。
- **队列 Worker 支持多队列、延迟、重试、死信等特性**  
  Worker 支持多队列监听、延迟任务、失败自动重试、死信队列、资源限制等，详见 `php xcat Queue` 命令帮助。
- **兼容原有数据库队列消费逻辑**  
  数据库队列相关的 Cron 逻辑未变，便于平滑迁移和回滚。

---

## 使用方式

### 1. 启用 Redis 队列

在 `.config.php` 中设置：

```php
$_ENV['enable_redis_queue'] = true;
```

并确保 Redis 相关配置正确。

### 2. 启动队列 Worker

```bash
php xcat Queue work
```

建议使用 Supervisor/Systemd等进程管理工具守护 Worker。

### 3. 队列管理命令

```bash
php xcat Queue status      # 查看队列状态
php xcat Queue failed      # 查看失败任务
php xcat Queue retry       # 重试失败任务
php xcat Queue flush       # 清空死信队列
php xcat Queue migrate     # 迁移数据库邮件队列到 Redis
```

---

## 兼容性与迁移

- 默认不开启 Redis 队列，配置后自动切换，无需修改业务代码
- 数据库队列消费逻辑保留，便于平滑迁移和回滚
- 详见 Queue.php 和 `php xcat Queue` 命令帮助