### PR TITLE
docs: update star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ This project is licensed under the MIT License. See [LICENSE](LICENSE) file for 
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Anankke/SSPanel-UIM&type=Date)](https://star-history.com/#Anankke/SSPanel-UIM&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Anankke/SSPanel-UIM&type=Date)](https://star-history.dera.page/#Anankke/SSPanel-UIM&Date)
 
 ---
 


### PR DESCRIPTION
The star history chart in the README is currently broken because of GitHub stargazer API restrictions. This change points it to a working mirror with the same data so the chart renders correctly again.