### PR TITLE
Fix backend error saving cryptomus_currency caused by missing parameter

### DIFF
--- a/resources/views/tabler/admin/setting/billing.tpl
+++ b/resources/views/tabler/admin/setting/billing.tpl
@@ -372,13 +372,13 @@
                                                 <span>The lifespan of the issued invoice.(In seconds)</span>
                                             </div>
                                         </div>
-{*                                        <div class="form-group mb-3 row">*}
-{*                                            <label class="form-label col-3 col-form-label">Currency</label>*}
-{*                                            <div class="col">*}
-{*                                                <input id="cryptomus_currency" type="text" class="form-control"*}
-{*                                                       value="{$settings['cryptomus_currency']}">*}
-{*                                            </div>*}
-{*                                        </div>*}
+                                        <div class="form-group mb-3 row">
+                                            <label class="form-label col-3 col-form-label">Currency</label>
+                                            <div class="col">
+                                                <input id="cryptomus_currency" type="text" class="form-control"
+                                                       value="{$settings['cryptomus_currency']}">
+                                            </div>
+                                        </div>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
Clicking the billing settings Save button omitted the cryptomus_currency parameter because the Cryptomus currency input was commented out. This caused the backend to report an error while saving cryptomus_currency. Restore the input field so the value is included in the save request.