### PR TITLE
Replace jQuery modal calls with Bootstrap 5 dialogs

### DIFF
--- a/resources/views/tabler/admin/announcement/create.tpl
+++ b/resources/views/tabler/admin/announcement/create.tpl
@@ -102,11 +102,11 @@
             success: function (data) {
                 if (data.ret === 1) {
                     $('#success-message').text(data.msg);
-                    $('#success-dialog').modal('show');
+                    successDialog.show();
                     window.setTimeout("location.href=top.document.referrer", {$config['jump_delay']});
                 } else {
                     $('#fail-message').text(data.msg);
-                    $('#fail-dialog').modal('show');
+                    failDialog.show();
                 }
             }
         })

--- a/resources/views/tabler/admin/announcement/edit.tpl
+++ b/resources/views/tabler/admin/announcement/edit.tpl
@@ -82,11 +82,11 @@
             success: function (data) {
                 if (data.ret === 1) {
                     $('#success-message').text(data.msg);
-                    $('#success-dialog').modal('show');
+                    successDialog.show();
                     window.setTimeout("location.href=top.document.referrer", {$config['jump_delay']});
                 } else {
                     $('#fail-message').text(data.msg);
-                    $('#fail-dialog').modal('show');
+                    failDialog.show();
                 }
             }
         })

--- a/resources/views/tabler/admin/announcement/index.tpl
+++ b/resources/views/tabler/admin/announcement/index.tpl
@@ -71,7 +71,7 @@
 
         function deleteAnn(ann_id) {
             $('#notice-message').text('确定删除此公告？');
-            $('#notice-dialog').modal('show');
+            noticeDialog.show();
             $('#notice-confirm').off('click').on('click', function () {
                 $.ajax({
                     url: "/admin/announcement/" + ann_id,
@@ -80,11 +80,11 @@
                     success: function (data) {
                         if (data.ret === 1) {
                             $('#success-message').text(data.msg);
-                            $('#success-dialog').modal('show');
+                            successDialog.show();
                             reloadTableAjax();
                         } else {
                             $('#fail-message').text(data.msg);
-                            $('#fail-dialog').modal('show');
+                            failDialog.show();
                         }
                     }
                 })

--- a/resources/views/tabler/admin/coupon.tpl
+++ b/resources/views/tabler/admin/coupon.tpl
@@ -157,11 +157,11 @@
                 success: function (data) {
                     if (data.ret === 1) {
                         $('#success-message').text(data.msg);
-                        $('#success-dialog').modal('show');
+                        successDialog.show();
                         reloadTableAjax();
                     } else {
                         $('#fail-message').text(data.msg);
-                        $('#fail-dialog').modal('show');
+                        failDialog.show();
                     }
                 }
             })
@@ -169,7 +169,7 @@
 
         function deleteCoupon(coupon_id) {
             $('#notice-message').text('确定删除此优惠码？');
-            $('#notice-dialog').modal('show');
+            noticeDialog.show();
             $('#notice-confirm').off('click').on('click', function () {
                 $.ajax({
                     url: "/admin/coupon/" + coupon_id,
@@ -178,11 +178,11 @@
                     success: function (data) {
                         if (data.ret === 1) {
                             $('#success-message').text(data.msg);
-                            $('#success-dialog').modal('show');
+                            successDialog.show();
                             reloadTableAjax();
                         } else {
                             $('#fail-message').text(data.msg);
-                            $('#fail-dialog').modal('show');
+                            failDialog.show();
                         }
                     }
                 })
@@ -191,7 +191,7 @@
 
         function disableCoupon(coupon_id) {
             $('#notice-message').text('确定禁用此优惠码？');
-            $('#notice-dialog').modal('show');
+            noticeDialog.show();
             $('#notice-confirm').off('click').on('click', function () {
                 $.ajax({
                     url: "/admin/coupon/" + coupon_id + "/disable",
@@ -200,11 +200,11 @@
                     success: function (data) {
                         if (data.ret === 1) {
                             $('#success-dialog').text(data.msg);
-                            $('#success-message').modal('show');
+                            successDialog.show();
                             reloadTableAjax();
                         } else {
                             $('#fail-message').text(data.msg);
-                            $('#fail-dialog').modal('show');
+                            failDialog.show();
                         }
                     }
                 })

--- a/resources/views/tabler/admin/detect.tpl
+++ b/resources/views/tabler/admin/detect.tpl
@@ -127,11 +127,11 @@
                 success: function (data) {
                     if (data.ret === 1) {
                         $('#success-message').text(data.msg);
-                        $('#success-dialog').modal('show');
+                        successDialog.show();
                         reloadTableAjax();
                     } else {
                         $('#fail-message').text(data.msg);
-                        $('#fail-dialog').modal('show');
+                        failDialog.show();
                     }
                 }
             })
@@ -139,7 +139,7 @@
 
         function deleteRule(rule_id) {
             $('#notice-message').text('确定删除此审计规则？');
-            $('#notice-dialog').modal('show');
+            noticeDialog.show();
             $('#notice-confirm').off('click').on('click', function () {
                 $.ajax({
                     url: "/admin/detect/" + rule_id,
@@ -148,11 +148,11 @@
                     success: function (data) {
                         if (data.ret === 1) {
                             $('#success-message').text(data.msg);
-                            $('#success-dialog').modal('show');
+                            successDialog.show();
                             reloadTableAjax();
                         } else {
                             $('#fail-message').text(data.msg);
-                            $('#fail-dialog').modal('show');
+                            failDialog.show();
                         }
                     }
                 })

--- a/resources/views/tabler/admin/docs/create.tpl
+++ b/resources/views/tabler/admin/docs/create.tpl
@@ -107,11 +107,11 @@
             success: function (data) {
                 if (data.ret === 1) {
                     $('#success-message').text(data.msg);
-                    $('#success-dialog').modal('show');
+                    successDialog.show();
                     tinyMCE.activeEditor.setContent(data.content);
                 } else {
                     $('#fail-message').text(data.msg);
-                    $('#fail-dialog').modal('show');
+                    failDialog.show();
                 }
             }
         })
@@ -131,11 +131,11 @@
             success: function (data) {
                 if (data.ret === 1) {
                     $('#success-message').text(data.msg);
-                    $('#success-dialog').modal('show');
+                    successDialog.show();
                     window.setTimeout("location.href=top.document.referrer", {$config['jump_delay']});
                 } else {
                     $('#fail-message').text(data.msg);
-                    $('#fail-dialog').modal('show');
+                    failDialog.show();
                 }
             }
         })

--- a/resources/views/tabler/admin/docs/edit.tpl
+++ b/resources/views/tabler/admin/docs/edit.tpl
@@ -87,11 +87,11 @@
             success: function (data) {
                 if (data.ret === 1) {
                     $('#success-message').text(data.msg);
-                    $('#success-dialog').modal('show');
+                    successDialog.show();
                     window.setTimeout("location.href=top.document.referrer", {$config['jump_delay']});
                 } else {
                     $('#fail-message').text(data.msg);
-                    $('#fail-dialog').modal('show');
+                    failDialog.show();
                 }
             }
         })

--- a/resources/views/tabler/admin/docs/index.tpl
+++ b/resources/views/tabler/admin/docs/index.tpl
@@ -71,7 +71,7 @@
 
         function deleteDoc(doc_id) {
             $('#notice-message').text('确定删除此文档？');
-            $('#notice-dialog').modal('show');
+            noticeDialog.show();
             $('#notice-confirm').off('click').on('click', function () {
                 $.ajax({
                     url: "/admin/docs/" + doc_id,
@@ -80,11 +80,11 @@
                     success: function (data) {
                         if (data.ret === 1) {
                             $('#success-message').text(data.msg);
-                            $('#success-dialog').modal('show');
+                            successDialog.show();
                             reloadTableAjax();
                         } else {
                             $('#fail-message').text(data.msg);
-                            $('#fail-dialog').modal('show');
+                            failDialog.show();
                         }
                     }
                 })

--- a/resources/views/tabler/admin/footer.tpl
+++ b/resources/views/tabler/admin/footer.tpl
@@ -84,6 +84,7 @@
 <script>
     let successDialog = new tabler.bootstrap.Modal(document.getElementById('success-dialog'));
     let failDialog = new tabler.bootstrap.Modal(document.getElementById('fail-dialog'));
+    let noticeDialog = new tabler.bootstrap.Modal(document.getElementById('notice-dialog'));
 
     htmx.on("htmx:afterRequest", function(evt) {
         if (evt.detail.xhr.getResponseHeader('HX-Refresh') === 'true' ||

--- a/resources/views/tabler/admin/giftcard.tpl
+++ b/resources/views/tabler/admin/giftcard.tpl
@@ -134,11 +134,11 @@
                 success: function (data) {
                     if (data.ret === 1) {
                         $('#success-message').text(data.msg);
-                        $('#success-dialog').modal('show');
+                        successDialog.show();
                         reloadTableAjax();
                     } else {
                         $('#fail-message').text(data.msg);
-                        $('#fail-dialog').modal('show');
+                        failDialog.show();
                     }
                 }
             })
@@ -146,7 +146,7 @@
 
         function deleteGiftCard(giftcard_id) {
             $('#notice-message').text('确定删除此礼品卡？');
-            $('#notice-dialog').modal('show');
+            noticeDialog.show();
             $('#notice-confirm').off('click').on('click', function () {
                 $.ajax({
                     url: "/admin/giftcard/" + giftcard_id,
@@ -155,11 +155,11 @@
                     success: function (data) {
                         if (data.ret === 1) {
                             $('#success-message').text(data.msg);
-                            $('#success-dialog').modal('show');
+                            successDialog.show();
                             reloadTableAjax();
                         } else {
                             $('#fail-message').text(data.msg);
-                            $('#fail-dialog').modal('show');
+                            failDialog.show();
                         }
                     }
                 })

--- a/resources/views/tabler/admin/invoice/view.tpl
+++ b/resources/views/tabler/admin/invoice/view.tpl
@@ -131,10 +131,10 @@
                 success: function (data) {
                     if (data.ret === 1) {
                         $('#success-message').text(data.msg);
-                        $('#success-dialog').modal('show');
+                        successDialog.show();
                     } else {
                         $('#fail-message').text(data.msg);
-                        $('#fail-dialog').modal('show');
+                        failDialog.show();
                     }
                 }
             })

--- a/resources/views/tabler/admin/node/create.tpl
+++ b/resources/views/tabler/admin/node/create.tpl
@@ -207,11 +207,11 @@
             success: function (data) {
                 if (data.ret === 1) {
                     $('#success-message').text(data.msg);
-                    $('#success-dialog').modal('show');
+                    successDialog.show();
                     window.setTimeout("location.href=top.document.referrer", {$config['jump_delay']});
                 } else {
                     $('#fail-message').text(data.msg);
-                    $('#fail-dialog').modal('show');
+                    failDialog.show();
                 }
             }
         })

--- a/resources/views/tabler/admin/node/edit.tpl
+++ b/resources/views/tabler/admin/node/edit.tpl
@@ -231,7 +231,7 @@
     let clipboard = new ClipboardJS('.copy');
     clipboard.on('success', function (e) {
         $('#success-message').text('已复制到剪切板');
-        $('#success-dialog').modal('show');
+        successDialog.show();
     });
 
     const container = document.getElementById('custom_config');
@@ -249,10 +249,10 @@
             success: function (data) {
                 if (data.ret === 1) {
                     $('#success-message').text(data.msg);
-                    $('#success-dialog').modal('show');
+                    successDialog.show();
                 } else {
                     $('#fail-message').text(data.msg);
-                    $('#fail-dialog').modal('show');
+                    failDialog.show();
                 }
             }
         })
@@ -266,10 +266,10 @@
             success: function (data) {
                 if (data.ret === 1) {
                     $('#success-message').text(data.msg);
-                    $('#success-dialog').modal('show');
+                    successDialog.show();
                 } else {
                     $('#fail-message').text(data.msg);
-                    $('#fail-dialog').modal('show');
+                    failDialog.show();
                 }
             }
         })
@@ -291,11 +291,11 @@
             success: function (data) {
                 if (data.ret === 1) {
                     $('#success-message').text(data.msg);
-                    $('#success-dialog').modal('show');
+                    successDialog.show();
                     window.setTimeout("location.href=top.document.referrer", {$config['jump_delay']});
                 } else {
                     $('#fail-message').text(data.msg);
-                    $('#fail-dialog').modal('show');
+                    failDialog.show();
                 }
             }
         })

--- a/resources/views/tabler/admin/node/index.tpl
+++ b/resources/views/tabler/admin/node/index.tpl
@@ -73,7 +73,7 @@
 
         function deleteNode(node_id) {
             $('#notice-message').text('确定删除此节点？');
-            $('#notice-dialog').modal('show');
+            noticeDialog.show();
             $('#notice-confirm').off('click').on('click', function () {
                 $.ajax({
                     url: "/admin/node/" + node_id,
@@ -82,11 +82,11 @@
                     success: function (data) {
                         if (data.ret === 1) {
                             $('#success-message').text(data.msg);
-                            $('#success-dialog').modal('show');
+                            successDialog.show();
                             reloadTableAjax();
                         } else {
                             $('#fail-message').text(data.msg);
-                            $('#fail-dialog').modal('show');
+                            failDialog.show();
                         }
                     }
                 })
@@ -95,7 +95,7 @@
 
         function copyNode(node_id) {
             $('#notice-message').text('确定复制此节点？');
-            $('#notice-dialog').modal('show');
+            noticeDialog.show();
             $('#notice-confirm').off('click').on('click', function () {
                 $.ajax({
                     url: "/admin/node/" + node_id + "/copy",
@@ -104,11 +104,11 @@
                     success: function (data) {
                         if (data.ret === 1) {
                             $('#success-message').text(data.msg);
-                            $('#success-dialog').modal('show');
+                            successDialog.show();
                             reloadTableAjax();
                         } else {
                             $('#fail-message').text(data.msg);
-                            $('#fail-dialog').modal('show');
+                            failDialog.show();
                         }
                     }
                 })

--- a/resources/views/tabler/admin/order/index.tpl
+++ b/resources/views/tabler/admin/order/index.tpl
@@ -104,7 +104,7 @@
 
         function deleteOrder(order_id) {
             $('#notice-message').text('确定删除此订单？');
-            $('#notice-dialog').modal('show');
+            noticeDialog.show();
             $('#notice-confirm').off('click').on('click', function () {
                 $.ajax({
                     url: "/admin/order/" + order_id,
@@ -113,11 +113,11 @@
                     success: function (data) {
                         if (data.ret === 1) {
                             $('#success-message').text(data.msg);
-                            $('#success-dialog').modal('show');
+                            successDialog.show();
                             reloadTableAjax();
                         } else {
                             $('#fail-message').text(data.msg);
-                            $('#fail-dialog').modal('show');
+                            failDialog.show();
                         }
                     }
                 })
@@ -126,7 +126,7 @@
 
         function cancelOrder(order_id) {
             $('#notice-message').text('确定取消此订单？如果关联账单已支付，将会退款至用户余额。');
-            $('#notice-dialog').modal('show');
+            noticeDialog.show();
             $('#notice-confirm').off('click').on('click', function () {
                 $.ajax({
                     url: "/admin/order/" + order_id + "/cancel",
@@ -135,11 +135,11 @@
                     success: function (data) {
                         if (data.ret === 1) {
                             $('#success-message').text(data.msg);
-                            $('#success-dialog').modal('show');
+                            successDialog.show();
                             reloadTableAjax();
                         } else {
                             $('#fail-message').text(data.msg);
-                            $('#fail-dialog').modal('show');
+                            failDialog.show();
                         }
                     }
                 })

--- a/resources/views/tabler/admin/order/view.tpl
+++ b/resources/views/tabler/admin/order/view.tpl
@@ -223,10 +223,10 @@
                 success: function (data) {
                     if (data.ret === 1) {
                         $('#success-message').text(data.msg);
-                        $('#success-dialog').modal('show');
+                        successDialog.show();
                     } else {
                         $('#fail-message').text(data.msg);
-                        $('#fail-dialog').modal('show');
+                        failDialog.show();
                     }
                 }
             })

--- a/resources/views/tabler/admin/product/create.tpl
+++ b/resources/views/tabler/admin/product/create.tpl
@@ -218,7 +218,7 @@
 
         if (emptyFields.length > 0) {
             $("#fail-message").text("请填写所有必要栏位");
-            $("#fail-dialog").modal("show");
+            failDialog.show();
         } else {
             $.ajax({
                 url: "/admin/product",
@@ -233,11 +233,11 @@
                 success: function (data) {
                     if (data.ret === 1) {
                         $("#success-message").text(data.msg);
-                        $("#success-dialog").modal("show");
+                        successDialog.show();
                         window.setTimeout("location.href=top.document.referrer", {$config["jump_delay"]});
                     } else {
                         $("#fail-message").text(data.msg);
-                        $("#fail-dialog").modal("show");
+                        failDialog.show();
                     }
                 }
             })

--- a/resources/views/tabler/admin/product/edit.tpl
+++ b/resources/views/tabler/admin/product/edit.tpl
@@ -230,7 +230,7 @@
 
         if (emptyFields.length > 0) {
             $("#fail-message").text("请填写所有必要栏位");
-            $("#fail-dialog").modal("show");
+            failDialog.show();
         } else {
             $.ajax({
                 url: '/admin/product/{$product->id}',
@@ -245,11 +245,11 @@
                 success: function (data) {
                     if (data.ret === 1) {
                         $('#success-message').text(data.msg);
-                        $('#success-dialog').modal('show');
+                        successDialog.show();
                         window.setTimeout("location.href=top.document.referrer", {$config['jump_delay']});
                     } else {
                         $('#fail-message').text(data.msg);
-                        $('#fail-dialog').modal('show');
+                        failDialog.show();
                     }
                 }
             })

--- a/resources/views/tabler/admin/product/index.tpl
+++ b/resources/views/tabler/admin/product/index.tpl
@@ -71,7 +71,7 @@
 
         function deleteProduct(product_id) {
             $('#notice-message').text('确定删除此产品？');
-            $('#notice-dialog').modal('show');
+            noticeDialog.show();
             $('#notice-confirm').off('click').on('click', function () {
                 $.ajax({
                     url: "/admin/product/" + product_id,
@@ -80,11 +80,11 @@
                     success: function (data) {
                         if (data.ret === 1) {
                             $('#success-message').text(data.msg);
-                            $('#success-dialog').modal('show');
+                            successDialog.show();
                             reloadTableAjax();
                         } else {
                             $('#fail-message').text(data.msg);
-                            $('#fail-dialog').modal('show');
+                            failDialog.show();
                         }
                     }
                 })
@@ -93,7 +93,7 @@
 
         function copyProduct(product_id) {
             $('#notice-message').text('确定复制此产品？');
-            $('#notice-dialog').modal('show');
+            noticeDialog.show();
             $('#notice-confirm').off('click').on('click', function () {
                 $.ajax({
                     url: "/admin/product/" + product_id + "/copy",
@@ -102,11 +102,11 @@
                     success: function (data) {
                         if (data.ret === 1) {
                             $('#success-message').text(data.msg);
-                            $('#success-dialog').modal('show');
+                            successDialog.show();
                             reloadTableAjax();
                         } else {
                             $('#fail-message').text(data.msg);
-                            $('#fail-dialog').modal('show');
+                            failDialog.show();
                         }
                     }
                 })

--- a/resources/views/tabler/admin/setting/billing.tpl
+++ b/resources/views/tabler/admin/setting/billing.tpl
@@ -405,10 +405,10 @@
                     success: function (data) {
                         if (data.ret === 1) {
                             $('#success-message').text(data.msg);
-                            $('#success-dialog').modal('show');
+                            successDialog.show();
                         } else {
                             $('#fail-message').text(data.msg);
-                            $('#fail-dialog').modal('show');
+                            failDialog.show();
                         }
                     }
                 })

--- a/resources/views/tabler/admin/setting/captcha.tpl
+++ b/resources/views/tabler/admin/setting/captcha.tpl
@@ -243,10 +243,10 @@
                     success: function (data) {
                         if (data.ret === 1) {
                             $('#success-message').text(data.msg);
-                            $('#success-dialog').modal('show');
+                            successDialog.show();
                         } else {
                             $('#fail-message').text(data.msg);
-                            $('#fail-dialog').modal('show');
+                            failDialog.show();
                         }
                     }
                 })

--- a/resources/views/tabler/admin/setting/cron.tpl
+++ b/resources/views/tabler/admin/setting/cron.tpl
@@ -227,10 +227,10 @@
                     success: function (data) {
                         if (data.ret === 1) {
                             $('#success-message').text(data.msg);
-                            $('#success-dialog').modal('show');
+                            successDialog.show();
                         } else {
                             $('#fail-message').text(data.msg);
-                            $('#fail-dialog').modal('show');
+                            failDialog.show();
                         }
                     }
                 })

--- a/resources/views/tabler/admin/setting/email.tpl
+++ b/resources/views/tabler/admin/setting/email.tpl
@@ -493,10 +493,10 @@
                     success: function (data) {
                         if (data.ret === 1) {
                             $('#success-message').text(data.msg);
-                            $('#success-dialog').modal('show');
+                            successDialog.show();
                         } else {
                             $('#fail-message').text(data.msg);
-                            $('#fail-dialog').modal('show');
+                            failDialog.show();
                         }
                     }
                 })
@@ -513,10 +513,10 @@
                     success: function (data) {
                         if (data.ret === 1) {
                             $('#success-message').text(data.msg);
-                            $('#success-dialog').modal('show');
+                            successDialog.show();
                         } else {
                             $('#fail-message').text(data.msg);
-                            $('#fail-dialog').modal('show');
+                            failDialog.show();
                         }
                     }
                 })

--- a/resources/views/tabler/admin/setting/feature.tpl
+++ b/resources/views/tabler/admin/setting/feature.tpl
@@ -229,10 +229,10 @@
                     success: function (data) {
                         if (data.ret === 1) {
                             $('#success-message').text(data.msg);
-                            $('#success-dialog').modal('show');
+                            successDialog.show();
                         } else {
                             $('#fail-message').text(data.msg);
-                            $('#fail-dialog').modal('show');
+                            failDialog.show();
                         }
                     }
                 })

--- a/resources/views/tabler/admin/setting/im.tpl
+++ b/resources/views/tabler/admin/setting/im.tpl
@@ -579,10 +579,10 @@
                     success: function (data) {
                         if (data.ret === 1) {
                             $('#success-message').text(data.msg);
-                            $('#success-dialog').modal('show');
+                            successDialog.show();
                         } else {
                             $('#fail-message').text(data.msg);
-                            $('#fail-dialog').modal('show');
+                            failDialog.show();
                         }
                     }
                 })

--- a/resources/views/tabler/admin/setting/llm.tpl
+++ b/resources/views/tabler/admin/setting/llm.tpl
@@ -284,10 +284,10 @@
                     success: function (data) {
                         if (data.ret === 1) {
                             $('#success-message').text(data.msg);
-                            $('#success-dialog').modal('show');
+                            successDialog.show();
                         } else {
                             $('#fail-message').text(data.msg);
-                            $('#fail-dialog').modal('show');
+                            failDialog.show();
                         }
                     }
                 })

--- a/resources/views/tabler/admin/setting/ref.tpl
+++ b/resources/views/tabler/admin/setting/ref.tpl
@@ -138,10 +138,10 @@
                     success: function (data) {
                         if (data.ret === 1) {
                             $('#success-message').text(data.msg);
-                            $('#success-dialog').modal('show');
+                            successDialog.show();
                         } else {
                             $('#fail-message').text(data.msg);
-                            $('#fail-dialog').modal('show');
+                            failDialog.show();
                         }
                     }
                 })

--- a/resources/views/tabler/admin/setting/reg.tpl
+++ b/resources/views/tabler/admin/setting/reg.tpl
@@ -196,10 +196,10 @@
                     success: function (data) {
                         if (data.ret === 1) {
                             $('#success-message').text(data.msg);
-                            $('#success-dialog').modal('show');
+                            successDialog.show();
                         } else {
                             $('#fail-message').text(data.msg);
-                            $('#fail-dialog').modal('show');
+                            failDialog.show();
                         }
                     }
                 })

--- a/resources/views/tabler/admin/setting/sub.tpl
+++ b/resources/views/tabler/admin/setting/sub.tpl
@@ -128,10 +128,10 @@
                     success: function (data) {
                         if (data.ret === 1) {
                             $('#success-message').text(data.msg);
-                            $('#success-dialog').modal('show');
+                            successDialog.show();
                         } else {
                             $('#fail-message').text(data.msg);
-                            $('#fail-dialog').modal('show');
+                            failDialog.show();
                         }
                     }
                 })

--- a/resources/views/tabler/admin/setting/support.tpl
+++ b/resources/views/tabler/admin/setting/support.tpl
@@ -135,10 +135,10 @@
                     success: function (data) {
                         if (data.ret === 1) {
                             $('#success-message').text(data.msg);
-                            $('#success-dialog').modal('show');
+                            successDialog.show();
                         } else {
                             $('#fail-message').text(data.msg);
-                            $('#fail-dialog').modal('show');
+                            failDialog.show();
                         }
                     }
                 })

--- a/resources/views/tabler/admin/ticket/index.tpl
+++ b/resources/views/tabler/admin/ticket/index.tpl
@@ -63,7 +63,7 @@
 
         function closeTicket(ticket_id) {
             $('#notice-message').text('确定关闭此工单？');
-            $('#notice-dialog').modal('show');
+            noticeDialog.show();
             $('#notice-confirm').off('click').on('click', function () {
                 $.ajax({
                     url: "/admin/ticket/" + ticket_id + '/close',
@@ -72,11 +72,11 @@
                     success: function (data) {
                         if (data.ret === 1) {
                             $('#success-message').text(data.msg);
-                            $('#success-dialog').modal('show');
+                            successDialog.show();
                             reloadTableAjax();
                         } else {
                             $('#fail-message').text(data.msg);
-                            $('#fail-dialog').modal('show');
+                            failDialog.show();
                         }
                     }
                 });
@@ -85,7 +85,7 @@
 
         function deleteTicket(ticket_id) {
             $('#notice-message').text('确定删除此工单？');
-            $('#notice-dialog').modal('show');
+            noticeDialog.show();
             $('#notice-confirm').off('click').on('click', function () {
                 $.ajax({
                     url: "/admin/ticket/" + ticket_id,
@@ -94,11 +94,11 @@
                     success: function (data) {
                         if (data.ret === 1) {
                             $('#success-message').text(data.msg);
-                            $('#success-dialog').modal('show');
+                            successDialog.show();
                             reloadTableAjax();
                         } else {
                             $('#fail-message').text(data.msg);
-                            $('#fail-dialog').modal('show');
+                            failDialog.show();
                         }
                     }
                 })

--- a/resources/views/tabler/admin/user/edit.tpl
+++ b/resources/views/tabler/admin/user/edit.tpl
@@ -287,11 +287,11 @@
             success: function (data) {
                 if (data.ret === 1) {
                     $('#success-message').text(data.msg);
-                    $('#success-dialog').modal('show');
+                    successDialog.show();
                     window.setTimeout("location.href=top.document.referrer", {$config['jump_delay']});
                 } else {
                     $('#fail-message').text(data.msg);
-                    $('#fail-dialog').modal('show');
+                    failDialog.show();
                 }
             }
         })

--- a/resources/views/tabler/admin/user/index.tpl
+++ b/resources/views/tabler/admin/user/index.tpl
@@ -133,11 +133,11 @@
                 success: function (data) {
                     if (data.ret === 1) {
                         $('#success-message').text(data.msg);
-                        $('#success-dialog').modal('show');
+                        successDialog.show();
                         reloadTableAjax();
                     } else {
                         $('#fail-message').text(data.msg);
-                        $('#fail-dialog').modal('show');
+                        failDialog.show();
                     }
                 }
             })
@@ -145,7 +145,7 @@
 
         function deleteUser(user_id) {
             $('#notice-message').text('确定删除此用户？');
-            $('#notice-dialog').modal('show');
+            noticeDialog.show();
             $('#notice-confirm').off('click').on('click', function () {
                 $.ajax({
                     url: "/admin/user/" + user_id,
@@ -154,11 +154,11 @@
                     success: function (data) {
                         if (data.ret === 1) {
                             $('#success-message').text(data.msg);
-                            $('#success-dialog').modal('show');
+                            successDialog.show();
                             reloadTableAjax();
                         } else {
                             $('#fail-message').text(data.msg);
-                            $('#fail-dialog').modal('show');
+                            failDialog.show();
                         }
                     }
                 })

--- a/resources/views/tabler/gateway/f2f.tpl
+++ b/resources/views/tabler/gateway/f2f.tpl
@@ -38,7 +38,7 @@
                     f2fQrcode.attr('href', data.qrcode);
                 } else {
                     $('#fail-message').text(data.msg);
-                    $('#fail-dialog').modal('show');
+                    failDialog.show();
                 }
             }
         })

--- a/resources/views/tabler/gateway/smogate.tpl
+++ b/resources/views/tabler/gateway/smogate.tpl
@@ -43,7 +43,7 @@
                     paymentButton.attr('href', data.qrcode);
                 } else {
                     $('#fail-message').text(data.msg);
-                    $('#fail-dialog').modal('show');
+                    failDialog.show();
                 }
             },
             error: () => {

--- a/resources/views/tabler/user/edit.tpl
+++ b/resources/views/tabler/user/edit.tpl
@@ -703,7 +703,7 @@
                 attResp = await startRegistration({ optionsJSON: options });
             } catch (error) {
                 $('#error-message').text(error.message);
-                $('#fail-dialog').modal('show');
+                failDialog.show();
                 throw error;
             }
             attResp.name = prompt("请输入设备名称:");
@@ -718,13 +718,13 @@
             const verificationJSON = await verificationResp.json();
             if (verificationJSON.ret === 1) {
                 $('#success-message').text(verificationJSON.msg);
-                $('#success-dialog').modal('show');
+                successDialog.show();
                 setTimeout(function () {
                     location.reload();
                 }, 1000);
             } else {
                 $('#error-message').text(verificationJSON.msg);
-                $('#fail-dialog').modal('show');
+                failDialog.show();
             }
         });
         document.getElementById('webauthnReg').addEventListener('click', async () => {
@@ -735,7 +735,7 @@
                 attResp = await startRegistration({ optionsJSON: options });
             } catch (error) {
                 $('#error-message').text(error.message);
-                $('#fail-dialog').modal('show');
+                failDialog.show();
                 throw error;
             }
             attResp.name = prompt("请输入设备名称:");
@@ -749,13 +749,13 @@
             const verificationJSON = await verificationResp.json();
             if (verificationJSON.ret === 1) {
                 $('#success-message').text(verificationJSON.msg);
-                $('#success-dialog').modal('show');
+                successDialog.show();
                 setTimeout(function () {
                     location.reload();
                 }, 1000);
             } else {
                 $('#error-message').text(verificationJSON.msg);
-                $('#fail-dialog').modal('show');
+                failDialog.show();
             }
         });
         {if $user->im_type === 0 && $user->im_value === ''}
@@ -825,13 +825,13 @@
             if (data.ret === 1) {
                 if (type === 'telegram') {
                     $('#success-message').text(data.msg);
-                    $('#success-dialog').modal('show');
+                    successDialog.show();
                 } else {
                     window.location.replace(data.redir);
                 }
             } else {
                 $('#error-message').text(data.msg);
-                $('#fail-dialog').modal('show');
+                failDialog.show();
             }
         }
         {/if}


### PR DESCRIPTION
The Tabler frontend uses Bootstrap 5, which does not provide the legacy jQuery modal plugin. Replace all legacy modal show calls across admin, user, and payment templates with Bootstrap 5 Modal instances, and initialize the shared admin notice dialog. This prevents modal is not a function errors while preserving the existing dialog behavior.