### PR TITLE
Skip JSON parsing for HX-Redirect responses

### DIFF
--- a/resources/views/tabler/user/footer.tpl
+++ b/resources/views/tabler/user/footer.tpl
@@ -132,6 +132,7 @@
 
     htmx.on("htmx:afterRequest", function(evt) {
         if (evt.detail.xhr.getResponseHeader('HX-Refresh') === 'true' ||
+            evt.detail.xhr.getResponseHeader('HX-Redirect') ||
             evt.detail.xhr.getResponseHeader('HX-Trigger'))
         {
             return;


### PR DESCRIPTION
The user footer attempted to parse every HTMX response as JSON unless HX-Refresh or HX-Trigger was present. Responses with HX-Redirect can have an empty body, causing JSON.parse to fail and showing an incorrect unexpected error message before navigation. Skip response processing when HX-Redirect is present, matching the admin footer behavior.