### PR TITLE
Fix loading of nested locale translation keys

### DIFF
--- a/src/Services/I18n.php
+++ b/src/Services/I18n.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace App\Services;
 
-use Symfony\Component\Translation\Loader\PhpFileLoader;
+use Symfony\Component\Translation\Loader\ArrayLoader;
 use Symfony\Component\Translation\Translator;
 use function basename;
 use function glob;
+use function is_array;
 use const BASE_PATH;
 
 final class I18n
@@ -35,13 +36,33 @@ final class I18n
     public static function getTranslator($lang = 'en_US'): Translator
     {
         $translator = new Translator($lang);
-        $translator->addLoader('php', new PhpFileLoader());
+        $translator->addLoader('array', new ArrayLoader());
+        $messages = require BASE_PATH . '/resources/locale/' . $lang . '.php';
+
         $translator->addResource(
-            'php',
-            BASE_PATH . '/resources/locale/' . $lang . '.php',
+            'array',
+            self::flattenMessages($messages),
             $lang
         );
 
         return $translator;
+    }
+
+    private static function flattenMessages(array $messages, string $prefix = ''): array
+    {
+        $flattened = [];
+
+        foreach ($messages as $key => $value) {
+            $messageId = $prefix === '' ? $key : $prefix . '.' . $key;
+
+            if (is_array($value)) {
+                $flattened += self::flattenMessages($value, $messageId);
+                continue;
+            }
+
+            $flattened[$messageId] = (string) $value;
+        }
+
+        return $flattened;
     }
 }

--- a/tests/Unit/Services/I18nTest.php
+++ b/tests/Unit/Services/I18nTest.php
@@ -20,6 +20,12 @@ describe('I18n::trans', function () {
         expect($translation)->toBe($expectedTranslation);
     });
 
+    it('returns nested translation for valid key and locale', function () {
+        $translation = I18n::trans('bot.user_not_bind', 'zh_CN');
+
+        expect($translation)->toBe('你未绑定本站账号，你可以进入网站的 **资料编辑**，在右下方绑定你的账号。');
+    });
+
     it('returns key when translation does not exist', function () {
         $key = 'non_existent_key';
         $lang = 'en_US';


### PR DESCRIPTION
The locale files organize messages under nested sections such as bot, but Symfony's PHP loader did not resolve dot-notation keys like bot.user_not_bind. Flatten nested locale arrays recursively and load them with ArrayLoader so any nested translation depth is supported. Add a regression test for the Telegram user_not_bind message.