### PR TITLE
Fix Telegram welcome message translation keys

### DIFF
--- a/src/Services/Bot/Telegram/Message.php
+++ b/src/Services/Bot/Telegram/Message.php
@@ -136,8 +136,8 @@ final class Message
 
             if (Config::obtain('enable_welcome_message')) {
                 $text = ($new_user->class > 0 ?
-                    I18n::trans('user_join_welcome_paid', $_ENV['locale']) :
-                    I18n::trans('user_join_welcome_free', $_ENV['locale']));
+                    I18n::trans('bot.user_join_welcome_paid', $_ENV['locale']) :
+                    I18n::trans('bot.user_join_welcome_free', $_ENV['locale']));
 
                 $this->replyWithMessage(
                     [


### PR DESCRIPTION
Telegram welcome messages used the top-level user_join_welcome_paid and user_join_welcome_free keys, while all locale files define them under the bot section. Use the correct bot-prefixed keys so welcome messages are translated instead of returning the key name.