### PR TITLE
Use a valid default locale in the config example

### DIFF
--- a/config/.config.example.php
+++ b/config/.config.example.php
@@ -98,7 +98,7 @@ $_ENV['enable_login_bind_device'] = true; //是否将登陆线程和设备绑定
 $_ENV['rememberMeDuration'] = 7;          //登录时记住账号时长天数
 $_ENV['timeZone'] = 'Asia/Shanghai';        //需使用 PHP 兼容的时区格式
 $_ENV['theme'] = 'tabler';                //默认主题
-$_ENV['locale'] = 'zh-CN';                //默认语言
+$_ENV['locale'] = 'zh_CN';                //默认语言，可选值：en_US、ja_JP、zh_CN、zh_TW
 $_ENV['jump_delay'] = 1000;               //跳转延时，单位ms
 $_ENV['keep_connect'] = false;            // 流量耗尽用户限速至 1Mbps
 


### PR DESCRIPTION
The example configuration used zh-CN as the default locale, but the project provides zh_CN.php. Set the default to zh_CN and document the available locale values: en_US, ja_JP, zh_CN, and zh_TW.